### PR TITLE
feat: 서버 상태 표시 기능 추가 (Status Indicator)

### DIFF
--- a/apps/backend/main.go
+++ b/apps/backend/main.go
@@ -17,6 +17,7 @@ import (
 	"taeu.kr/cohesion/internal/space"
 	spaceHandler "taeu.kr/cohesion/internal/space/handler"
 	spaceStore "taeu.kr/cohesion/internal/space/store"
+	"taeu.kr/cohesion/internal/status"
 	"taeu.kr/cohesion/internal/webdav"
 	webdavHandler "taeu.kr/cohesion/internal/webdav/handler"
 )
@@ -59,6 +60,7 @@ func main() {
 	browseHandler := browseHandler.NewHandler(browseService, spaceService)
 	webDavService := webdav.NewService(spaceService)
 	webDavHandler := webdavHandler.NewHandler(webDavService)
+	statusHandler := status.NewHandler(db, spaceService)
 
 	// 라우터 생성
 	mux := http.NewServeMux()
@@ -73,6 +75,7 @@ func main() {
 	// Api 핸들러 등록
 	spaceHandler.RegisterRoutes(mux)
 	browseHandler.RegisterRoutes(mux)
+	statusHandler.RegisterRoutes(mux)
 
 	// WebDAV 핸들러 등록
 	mux.Handle("/dav/", web.Handler(func(w http.ResponseWriter, r *http.Request) *web.Error {

--- a/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
@@ -1,0 +1,120 @@
+import { Popover, theme } from 'antd';
+import { useServerStatus } from '@/features/status/hooks/useServerStatus';
+import type { ProtocolStatus } from '@/features/status/types';
+
+const PROTOCOL_LABELS: Record<string, string> = {
+  http: 'HTTP',
+  webdav: 'WebDAV',
+  ftp: 'FTP',
+};
+
+function StatusDot({ color, size = 8 }: { color: string; size?: number }) {
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        backgroundColor: color,
+      }}
+    />
+  );
+}
+
+function getStatusColor(status: ProtocolStatus['status']) {
+  switch (status) {
+    case 'healthy':
+      return '#52c41a';
+    case 'unhealthy':
+      return '#ff4d4f';
+    case 'unavailable':
+      return '#8c8c8c';
+  }
+}
+
+function getStatusLabel(status: ProtocolStatus['status']) {
+  switch (status) {
+    case 'healthy':
+      return '정상';
+    case 'unhealthy':
+      return '오류';
+    case 'unavailable':
+      return '중지';
+  }
+}
+
+function PopoverContent({ protocols }: { protocols: Record<string, ProtocolStatus> }) {
+  const { token } = theme.useToken();
+
+  return (
+    <div style={{ minWidth: 160 }}>
+      <div style={{ fontSize: 12, color: token.colorTextSecondary, marginBottom: 8 }}>
+        Protocols
+      </div>
+      {Object.entries(protocols).map(([key, proto]) => (
+        <div
+          key={key}
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '4px 0',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <StatusDot color={getStatusColor(proto.status)} />
+            <span style={{ fontSize: 13 }}>{PROTOCOL_LABELS[key] || key}</span>
+          </div>
+          <span style={{ fontSize: 12, color: token.colorTextSecondary }}>
+            {getStatusLabel(proto.status)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ServerStatus() {
+  const { token } = theme.useToken();
+  const { status, isServerUp } = useServerStatus();
+
+  const dotColor = isServerUp ? '#52c41a' : '#ff4d4f';
+
+  return (
+    <Popover
+      content={
+        status?.protocols ? (
+          <PopoverContent protocols={status.protocols} />
+        ) : (
+          <div style={{ fontSize: 12, color: token.colorTextSecondary }}>
+            서버에 연결할 수 없습니다
+          </div>
+        )
+      }
+      trigger="click"
+      placement="bottomLeft"
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          cursor: 'pointer',
+          padding: '4px 8px',
+          borderRadius: 4,
+          transition: 'background 0.2s',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = token.colorBgTextHover;
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = 'transparent';
+        }}
+      >
+        <StatusDot color={dotColor} />
+        <span style={{ fontSize: 13, color: token.colorTextSecondary }}>Status</span>
+      </div>
+    </Popover>
+  );
+}

--- a/apps/frontend/src/components/layout/MainLayout/index.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/index.tsx
@@ -1,6 +1,7 @@
 import { ConfigProvider, Layout, Switch, theme } from "antd";
 import { Outlet } from "react-router";
 import MainSider from "./MainSider";
+import ServerStatus from "./ServerStatus";
 import { useState } from "react";
 import { useSpaces } from "@/features/space/hooks/useSpaces";
 import type { Space } from "@/features/space/types";
@@ -42,8 +43,9 @@ const PageLayout = ({ isDarkMode, onThemeChange }: { isDarkMode: boolean, onThem
           background: token.colorBgContainer
         }}
       >
-        <div style={{ color: token.colorText, fontSize: '20px' }}>
-            Cohesion
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+            <div style={{ color: token.colorText, fontSize: '20px' }}>Cohesion</div>
+            <ServerStatus />
         </div>
         <Switch checked={isDarkMode} onChange={onThemeChange} checkedChildren="Dark" unCheckedChildren="Light" />
       </Header>

--- a/apps/frontend/src/features/status/hooks/useServerStatus.ts
+++ b/apps/frontend/src/features/status/hooks/useServerStatus.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { StatusResponse } from '../types';
+
+const POLL_INTERVAL = 30000;
+
+export function useServerStatus() {
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isServerUp, setIsServerUp] = useState(false);
+  const intervalRef = useRef<number | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch('/api/status');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data: StatusResponse = await response.json();
+      setStatus(data);
+      setIsServerUp(true);
+    } catch {
+      setStatus(null);
+      setIsServerUp(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+
+    intervalRef.current = window.setInterval(fetchStatus, POLL_INTERVAL);
+
+    return () => {
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+      }
+    };
+  }, [fetchStatus]);
+
+  return { status, isLoading, isServerUp, refetch: fetchStatus };
+}

--- a/apps/frontend/src/features/status/types.ts
+++ b/apps/frontend/src/features/status/types.ts
@@ -1,0 +1,8 @@
+export interface ProtocolStatus {
+  status: 'healthy' | 'unhealthy' | 'unavailable';
+  message: string;
+}
+
+export interface StatusResponse {
+  protocols: Record<string, ProtocolStatus>;
+}


### PR DESCRIPTION
## Summary\n- 헤더 \"Cohesion\" 옆에 서버 상태(● Status) 표시\n- 클릭 시 Popover로 프로토콜별 상태 확인 (HTTP, WebDAV, FTP)\n- 백엔드 `/api/status` 엔드포인트 추가 (DB ping, Space 서비스 체크)\n- 30초 간격 자동 polling, 다크/라이트 모드 대응\n\n## Test plan\n- [ ] 백엔드 서버 실행 후 `curl localhost:3000/api/status` 응답 확인\n- [ ] 프론트엔드 헤더에서 초록 dot + Status 표시 확인\n- [ ] Status 클릭 시 Popover에 HTTP(정상), WebDAV(정상), FTP(중지) 표시 확인\n- [ ] 다크/라이트 모드 전환 시 UI 정상 확인