### PR TITLE
refactor: FolderTree Space 하위 노드 탐색을 Space API로 전환 (#29)

### DIFF
--- a/apps/frontend/src/features/browse/hooks/useBrowseApi.ts
+++ b/apps/frontend/src/features/browse/hooks/useBrowseApi.ts
@@ -33,5 +33,10 @@ export function useBrowseApi() {
     return await fetchData(url);
   }, [fetchData]);
 
-  return { isLoading, error, fetchBaseDirectories, fetchDirectoryContents };
+  const fetchSpaceDirectoryContents = useCallback(async (spaceId: number, relativePath: string) => {
+    const url = `/api/spaces/${spaceId}/browse?path=${encodeURIComponent(relativePath)}`;
+    return await fetchData(url);
+  }, [fetchData]);
+
+  return { isLoading, error, fetchBaseDirectories, fetchDirectoryContents, fetchSpaceDirectoryContents };
 }


### PR DESCRIPTION
## 개요

사이드바 FolderTree에서 Space 노드를 펼칠 때 `/api/browse`를 사용하던 부분을 `/api/spaces/{id}/browse`로 전환합니다.

Closes #29

## 변경 사항

### `useBrowseApi.ts`
- `fetchSpaceDirectoryContents(spaceId, relativePath)` 함수 추가
  - `/api/spaces/{id}/browse?path={relativePath}` 호출

### `FolderTree.tsx` `onLoadData`
- Space 노드(`space-` prefix) 펼칠 때: `fetchSpaceDirectoryContents` 사용
  - Space 루트: `relativePath = ''`
  - Space 하위 노드: `absolutePath → relativePath` 변환 후 호출
- 비-Space 노드(시스템 탐색, `showBaseDirectories`): 기존 `fetchDirectoryContents` 유지

## Acceptance Criteria 검증

- ✅ Space 노드 펼칠 때 `/api/spaces/{id}/browse` 호출
- ✅ Space 등록 모달 시스템 탐색은 `/api/browse` 유지
- ✅ TypeScript 타입 에러 없음