### PR TITLE
feat: 폴더 그리드 자동 컬럼과 썸네일 핏 개선

### DIFF
--- a/apps/frontend/src/features/browse/components/FileExplorer.tsx
+++ b/apps/frontend/src/features/browse/components/FileExplorer.tsx
@@ -9,7 +9,7 @@ const FileExplorer: React.FC = () => {
   return (
     <div style={{
       height: 'calc(100vh - 64px)',
-      overflow: 'auto',
+      overflow: 'hidden',
       padding: '16px',
       background: token.colorBgLayout
     }}>

--- a/apps/frontend/src/features/browse/components/FolderContent.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent.tsx
@@ -315,7 +315,7 @@ const FolderContent: React.FC = () => {
           onSortChange={setSortConfig}
         />
       ) : (
-        <div ref={gridContainerRef} style={{ flex: 1, overflow: 'auto' }}>
+        <div ref={gridContainerRef} style={{ flex: 1, minWidth: 0, overflowY: 'auto', overflowX: 'hidden' }}>
           <FolderContentGrid
             dataSource={sortedContent}
             loading={isLoading}

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Row, Col, Card, Empty } from 'antd';
+import { Card, Empty } from 'antd';
 import { FolderFilled, FileOutlined } from '@ant-design/icons';
 import type { FileNode } from '../../types';
 import { formatSize } from '../../constants';
@@ -44,17 +44,23 @@ const FolderContentGrid: React.FC<FolderContentGridProps> = ({
   spacePath,
 }) => {
   return (
-    <Row gutter={[16, 16]}>
+    <>
       {dataSource.length === 0 && !loading ? (
-        <Col span={24}>
-          <Empty description="이 폴더는 비어 있습니다." />
-        </Col>
+        <Empty description="이 폴더는 비어 있습니다." />
       ) : (
-        dataSource.map((item, index) => {
-          const isSelected = selectedItems.has(item.path);
-          return (
-            <Col key={item.path} xs={12} sm={8} md={6} lg={4} xl={3}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(172px, 220px))',
+            justifyContent: 'start',
+            gap: '12px',
+          }}
+        >
+          {dataSource.map((item, index) => {
+            const isSelected = selectedItems.has(item.path);
+            return (
               <Card
+                key={item.path}
                 ref={(el) => {
                   if (el && itemsRef) {
                     itemsRef.current.set(item.path, el);
@@ -85,16 +91,18 @@ const FolderContentGrid: React.FC<FolderContentGridProps> = ({
                       : undefined,
                   userSelect: 'none',
                 }}
-                styles={{ body: { padding: '16px 8px' } }}
+                styles={{ body: { padding: '12px 8px' } }}
               >
-                <div style={{ marginBottom: '8px' }}>
+                <div style={{ marginBottom: '6px' }}>
                   {item.isDir ? (
                     <div
                       style={{
-                        height: '120px',
+                        height: '128px',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
+                        borderRadius: '6px',
+                        backgroundColor: 'rgba(140, 140, 140, 0.08)',
                       }}
                     >
                       <FolderFilled style={{ fontSize: '48px', color: '#ffca28' }} />
@@ -105,15 +113,18 @@ const FolderContentGrid: React.FC<FolderContentGridProps> = ({
                       spacePath={spacePath}
                       path={item.path}
                       alt={item.name}
-                      size={120}
+                      size={128}
+                      fit="cover"
                     />
                   ) : (
                     <div
                       style={{
-                        height: '120px',
+                        height: '128px',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
+                        borderRadius: '6px',
+                        backgroundColor: 'rgba(140, 140, 140, 0.08)',
                       }}
                     >
                       <FileOutlined style={{ fontSize: '48px', color: '#8c8c8c' }} />
@@ -135,11 +146,11 @@ const FolderContentGrid: React.FC<FolderContentGridProps> = ({
                   </div>
                 )}
               </Card>
-            </Col>
-          );
-        })
+            );
+          })}
+        </div>
       )}
-    </Row>
+    </>
   );
 };
 

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentSelectionBar.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentSelectionBar.tsx
@@ -33,11 +33,12 @@ const FolderContentSelectionBar: React.FC<FolderContentSelectionBarProps> = ({
         borderRadius: '4px',
         display: 'flex',
         alignItems: 'center',
+        flexWrap: 'wrap',
         gap: '16px',
       }}
     >
       <span style={{ fontWeight: 'bold', color: '#1890ff' }}>✓ {selectedCount}개 선택됨</span>
-      <AntSpace size="small">
+      <AntSpace size="small" wrap>
         <Button size="small" icon={<DownloadOutlined />} onClick={onDownload}>
           다운로드
         </Button>

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentToolbar.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentToolbar.tsx
@@ -23,9 +23,19 @@ const FolderContentToolbar: React.FC<FolderContentToolbarProps> = ({
   onSortChange,
 }) => {
   return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-      <Breadcrumb items={breadcrumbItems} />
-      <AntSpace>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: '8px 16px',
+      }}
+    >
+      <div style={{ flex: '1 1 320px', minWidth: 0, overflow: 'hidden' }}>
+        <Breadcrumb items={breadcrumbItems} />
+      </div>
+      <AntSpace wrap>
         <Button icon={<UploadOutlined />} onClick={onUpload}>
           업로드
         </Button>

--- a/apps/frontend/src/features/browse/components/ImageThumbnail.tsx
+++ b/apps/frontend/src/features/browse/components/ImageThumbnail.tsx
@@ -8,6 +8,7 @@ interface ImageThumbnailProps {
   path: string;       // 절대 경로
   alt: string;
   size?: number;
+  fit?: 'contain' | 'cover';
 }
 
 export const ImageThumbnail: React.FC<ImageThumbnailProps> = ({
@@ -16,6 +17,7 @@ export const ImageThumbnail: React.FC<ImageThumbnailProps> = ({
   path,
   alt,
   size = 120,
+  fit = 'cover',
 }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -27,10 +29,13 @@ export const ImageThumbnail: React.FC<ImageThumbnailProps> = ({
     return (
       <div
         style={{
+          width: '100%',
           height: size,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
+          borderRadius: '6px',
+          backgroundColor: 'rgba(140, 140, 140, 0.08)',
         }}
       >
         <FileOutlined style={{ fontSize: '48px', color: '#8c8c8c' }} />
@@ -41,11 +46,15 @@ export const ImageThumbnail: React.FC<ImageThumbnailProps> = ({
   return (
     <div
       style={{
+        width: '100%',
         height: size,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         position: 'relative',
+        overflow: 'hidden',
+        borderRadius: '6px',
+        backgroundColor: 'rgba(140, 140, 140, 0.08)',
       }}
     >
       {loading && (
@@ -58,10 +67,9 @@ export const ImageThumbnail: React.FC<ImageThumbnailProps> = ({
         alt={alt}
         loading="lazy"
         style={{
-          maxWidth: '100%',
-          maxHeight: size,
-          objectFit: 'contain',
-          borderRadius: '4px',
+          width: '100%',
+          height: '100%',
+          objectFit: fit,
           opacity: loading ? 0 : 1,
           transition: 'opacity 0.2s',
         }}

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,20 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### Folder Explorer Grid 자동 컬럼 배치 + 가로 스크롤 억제 (2026-02-13)
+- **결정**: Grid 뷰를 브레이크포인트 고정 컬럼이 아닌 `auto-fit + minmax` 기반 자동 컬럼 배치로 전환하고, 가로 스크롤 억제를 위해 스크롤 축을 분리한다.
+- **이유**:
+  - 해상도별 고정 단계(예: 6/4/2)보다 연속적인 폭 적응이 가능해 공간 활용이 더 좋음.
+  - 카드 최소 폭을 유지하면서 가능한 한 많은 항목을 한 줄에 표시할 수 있음.
+  - 가로 스크롤의 주 원인(중첩 overflow, toolbar/selection bar 비랩핑) 제거.
+- **구현**:
+  - `FolderContentGrid`: CSS Grid `gridTemplateColumns: repeat(auto-fit, minmax(180px, 1fr))` 적용.
+  - `FileExplorer`: 외곽 `overflow: hidden`.
+  - `FolderContent` Grid 컨테이너: `overflowY: auto`, `overflowX: hidden`, `minWidth: 0`.
+  - `FolderContentToolbar`, `FolderContentSelectionBar`: `flexWrap` 및 `AntSpace wrap` 적용.
+  - 썸네일 표시: `ImageThumbnail`을 `object-fit: cover` 중심으로 변경하고 프리뷰 박스(`128px`)에 밀착되게 렌더링.
+  - 밀도 조정: Grid `gap`을 16px → 12px, 카드 body padding을 16px → 12px으로 축소.
+
 ### 트리 targeted invalidation 적용 (2026-02-13, #35)
 - **문제**: 파일 작업 후 트리를 전역 invalidate하여 불필요한 노드 재초기화/재로딩이 발생.
 - **결정**: invalidate payload에 영향 경로를 포함하고, 트리는 해당 노드만 부분 무효화.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,13 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **Folder Explorer 가로 스크롤 최소화 및 자동 컬럼 배치 적용 완료** (2026-02-13):
+    - Grid 카드 레이아웃을 `auto-fit + minmax` 기반의 자동 컬럼 배치로 전환.
+    - 카드 단일 노출 시 과도한 확장을 방지하기 위해 카드 최대 폭(220px) 제한을 적용.
+    - 외곽 컨테이너 스크롤을 숨기고, Grid 영역을 `overflowY` 중심으로 분리하여 가로 스크롤 발생을 억제.
+    - Toolbar/SelectionBar에 wrap을 적용해 좁은 해상도에서 버튼/경로가 줄바꿈되도록 개선.
+    - 썸네일을 `cover` 기준으로 카드 프리뷰 영역에 밀착되게 표시하고, 카드/그리드 간격을 더 촘촘하게 조정.
+    - 검증: `pnpm -C apps/frontend build` 통과, 1200/900/700 폭에서 가로 오버플로우 없음 확인.
 - **트리 targeted invalidation 최적화 완료** (2026-02-13, #35):
     - 전역 리셋 방식(`treeRefreshVersion` 단독)에서 경로 기반 무효화 타깃(`treeInvalidationTargets`) 방식으로 확장.
     - 파일 작업 후 영향 경로(소스 부모/대상 부모)만 invalidate 하도록 변경.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -65,3 +65,4 @@
 - [x] 파일 작업(복사/이동/삭제/이름변경/폴더생성) 후 트리 자동 invalidate 반영
 - [x] 트리 targeted invalidation 최적화 (영향 노드만 부분 갱신) (#35)
 - [x] 실행 환경 문서 위치 정리 (`docs/AGENTS.md` → `AGENTS.md`)
+- [x] Folder Explorer Grid 자동 컬럼 배치(auto-fit/minmax) 및 가로 스크롤 억제 레이아웃 적용


### PR DESCRIPTION
## 관련 이슈
- closes #36

## 변경 사항
- Grid 레이아웃을 브레이크포인트 고정 컬럼에서 `auto-fit/minmax` 자동 컬럼 배치로 전환
- 카드 최대 폭(220px) 제한으로 단일 아이템 과확장 방지
- 썸네일 렌더링을 `object-fit: cover` 중심으로 조정하여 프리뷰 영역 밀착 표시
- Grid 카드 밀도 조정 (gap/padding 축소)
- 가로 스크롤 억제를 위해 적용했던 overflow 축 분리 및 툴바/선택바 wrap 유지
- `docs/ai-context` 동기화 (`status.md`, `todo.md`, `decision_log.md`)

## 검증
- `pnpm -C apps/frontend build` 통과
- 브라우저 확인: 1200/900/700 폭에서 가로 오버플로우 없음
- 브라우저 확인: Grid 뷰 썸네일 `object-fit: cover` 적용 확인