### PR TITLE
fix: antd 정적 message 컨텍스트 경고 제거

### DIFF
--- a/apps/frontend/src/features/browse/components/DestinationPickerModal.tsx
+++ b/apps/frontend/src/features/browse/components/DestinationPickerModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Modal, message, theme } from 'antd';
+import { Modal, theme, App } from 'antd';
 import FolderTree from './FolderTree';
 import type { Space } from '@/features/space/types';
 
@@ -22,6 +22,7 @@ const DestinationPickerModal: React.FC<DestinationPickerModalProps> = ({
   onConfirm,
   onCancel,
 }) => {
+  const { message } = App.useApp();
   const [selectedDestination, setSelectedDestination] = useState<string>('');
   const [selectedDestinationSpace, setSelectedDestinationSpace] = useState<Space | undefined>();
 

--- a/apps/frontend/src/features/browse/hooks/useDragAndDrop.ts
+++ b/apps/frontend/src/features/browse/hooks/useDragAndDrop.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { message } from 'antd';
+import { App } from 'antd';
 import type { FileNode, DragData } from '../types';
 
 interface UseDragAndDropParams {
@@ -29,6 +29,7 @@ export function useDragAndDrop({
   selectedItems,
   currentPath,
 }: UseDragAndDropParams): UseDragAndDropReturn {
+  const { message } = App.useApp();
   const [isDragging, setIsDragging] = useState(false);
   const [dragOverFolder, setDragOverFolder] = useState<string | null>(null);
 

--- a/apps/frontend/src/features/space/components/DirectorySetupModal.tsx
+++ b/apps/frontend/src/features/space/components/DirectorySetupModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Input, message } from "antd";
+import { Modal, Input, App } from "antd";
 import FolderTree from "../../browse/components/FolderTree";
 import { useState } from "react";
 import { useSpaceStore } from "@/stores/spaceStore";
@@ -12,6 +12,7 @@ export default function DirectorySetupModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
+  const { message } = App.useApp();
   const [selectedPath, setSelectedPath] = useState<string>('');
   const [spaceName, setSpaceName] = useState<string>('');
   const [spaceDesc, setSpaceDesc] = useState<string>('');

--- a/apps/frontend/src/pages/Settings/index.tsx
+++ b/apps/frontend/src/pages/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { ConfigProvider, Layout, Menu, Typography, Button, theme } from 'antd';
+import { ConfigProvider, Layout, Menu, Typography, Button, theme, App } from 'antd';
 import {
   AppstoreOutlined,
   BgColorsOutlined,
@@ -129,7 +129,9 @@ const Settings = () => {
 
   return (
     <ConfigProvider theme={{ algorithm: currentAlgorithm }}>
-      <SettingsPage />
+      <App>
+        <SettingsPage />
+      </App>
     </ConfigProvider>
   );
 };

--- a/apps/frontend/src/pages/Settings/sections/AdvancedSettings.tsx
+++ b/apps/frontend/src/pages/Settings/sections/AdvancedSettings.tsx
@@ -1,10 +1,11 @@
-import { Card, Button, Typography, Space, message, Popconfirm } from 'antd';
+import { Card, Button, Typography, Space, Popconfirm, App } from 'antd';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { DeleteOutlined, ReloadOutlined } from '@ant-design/icons';
 
 const { Title, Text } = Typography;
 
 const AdvancedSettings = () => {
+  const { message } = App.useApp();
   const resetToDefaults = useSettingsStore((state) => state.resetToDefaults);
 
   const handleReset = () => {

--- a/apps/frontend/src/pages/Settings/sections/ServerSettings.tsx
+++ b/apps/frontend/src/pages/Settings/sections/ServerSettings.tsx
@@ -1,4 +1,4 @@
-import { Card, Switch, InputNumber, Typography, Space, Alert, Divider, Button, message, Modal } from 'antd';
+import { Card, Switch, InputNumber, Typography, Space, Alert, Divider, Button, App } from 'antd';
 import { ReloadOutlined, SaveOutlined } from '@ant-design/icons';
 import { useState, useEffect } from 'react';
 import { getConfig, updateConfig, restartServer, waitForReconnect, type Config } from '@/api/config';
@@ -6,6 +6,7 @@ import { getConfig, updateConfig, restartServer, waitForReconnect, type Config }
 const { Title, Text } = Typography;
 
 const ServerSettings = () => {
+  const { message, modal } = App.useApp();
   const [config, setConfig] = useState<Config | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -48,7 +49,7 @@ const ServerSettings = () => {
   };
 
   const handleRestart = async () => {
-    Modal.confirm({
+    modal.confirm({
       title: '서버 재시작',
       content: '서버를 재시작하시겠습니까? 잠시 연결이 끊어질 수 있습니다.',
       okText: '재시작',

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,17 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### antd 정적 message 사용 제거 (2026-02-13)
+- **문제**: `message` 정적 API 사용 시 동적 테마 컨텍스트를 소비하지 못해 경고 발생.
+- **결정**: 정적 `message`/`Modal.confirm` 호출 대신 `App.useApp()`에서 제공되는 `message`/`modal` 인스턴스를 사용.
+- **구현**:
+  - `/settings` 라우트의 `ConfigProvider` 하위에 `App` 프로바이더 추가.
+  - `AdvancedSettings`, `ServerSettings`, `DirectorySetupModal`, `DestinationPickerModal`, `useDragAndDrop`를 컨텍스트 기반 API로 전환.
+- **이유**:
+  - Ant Design 권장 패턴과 일치.
+  - 테마/컨텍스트 반영 가능한 일관된 메시지 렌더링 확보.
+  - 콘솔 경고 제거로 디버깅 신뢰도 개선.
+
 ### Folder Explorer Grid 자동 컬럼 배치 + 가로 스크롤 억제 (2026-02-13)
 - **결정**: Grid 뷰를 브레이크포인트 고정 컬럼이 아닌 `auto-fit + minmax` 기반 자동 컬럼 배치로 전환하고, 가로 스크롤 억제를 위해 스크롤 축을 분리한다.
 - **이유**:

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,10 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **Ant Design message 컨텍스트 경고 제거 완료** (2026-02-13):
+    - `/settings` 라우트에 `antd` `App` 프로바이더를 추가해 메시지 컨텍스트를 보장.
+    - 정적 `message`/`Modal.confirm` 호출을 `App.useApp()` 기반 호출로 전환.
+    - 검증: `pnpm -s build` (in `apps/frontend`) 통과.
 - **Folder Explorer 가로 스크롤 최소화 및 자동 컬럼 배치 적용 완료** (2026-02-13):
     - Grid 카드 레이아웃을 `auto-fit + minmax` 기반의 자동 컬럼 배치로 전환.
     - 카드 단일 노출 시 과도한 확장을 방지하기 위해 카드 최대 폭(220px) 제한을 적용.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -66,3 +66,4 @@
 - [x] 트리 targeted invalidation 최적화 (영향 노드만 부분 갱신) (#35)
 - [x] 실행 환경 문서 위치 정리 (`docs/AGENTS.md` → `AGENTS.md`)
 - [x] Folder Explorer Grid 자동 컬럼 배치(auto-fit/minmax) 및 가로 스크롤 억제 레이아웃 적용
+- [x] antd 정적 message/Modal 경고 제거 (`App.useApp` 전환, Settings `App` 프로바이더 추가)


### PR DESCRIPTION
## 요약
- `/settings` 라우트에 `App` 프로바이더를 추가해 antd 컨텍스트를 보장했습니다.
- 정적 `message`/`Modal.confirm` 호출을 `App.useApp()` 기반 `message`/`modal` 인스턴스로 전환했습니다.
- AI 컨텍스트 문서(`status.md`, `todo.md`, `decision_log.md`)를 최신화했습니다.

## 변경 파일
- `apps/frontend/src/pages/Settings/index.tsx`
- `apps/frontend/src/pages/Settings/sections/AdvancedSettings.tsx`
- `apps/frontend/src/pages/Settings/sections/ServerSettings.tsx`
- `apps/frontend/src/features/space/components/DirectorySetupModal.tsx`
- `apps/frontend/src/features/browse/components/DestinationPickerModal.tsx`
- `apps/frontend/src/features/browse/hooks/useDragAndDrop.ts`
- `docs/ai-context/decision_log.md`
- `docs/ai-context/status.md`
- `docs/ai-context/todo.md`

## 검증
- `cd apps/frontend && pnpm -s build` 통과

Closes #40