### PR TITLE
fix: Header Status Popover 정렬 개선

### DIFF
--- a/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
@@ -110,7 +110,8 @@ export default function ServerStatus() {
         )
       }
       trigger="hover"
-      placement="bottomLeft"
+      placement="bottom"
+      arrow={{ pointAtCenter: true }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
         <StatusDot color={dotColor} />


### PR DESCRIPTION
## 요약
### 문제
- `Status` 텍스트 대비 팝오버가 좌측 기준으로 열려 멀어 보이는 UX 이슈가 있었습니다.

### 해결
- `Popover` 배치를 `bottomLeft`에서 `bottom`으로 변경했습니다.
- `arrow={{ pointAtCenter: true }}`를 추가해 트리거 중심 정렬을 강화했습니다.

### 기대 효과
- `Status` 영역과 팝오버의 시각적 연결이 더 자연스럽습니다.

## 관련 이슈
- Closes #48

## 변경 사항
- `apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx`
  - `placement="bottom"`
  - `arrow={{ pointAtCenter: true }}`

## 범위
### In Scope
- Header Status Popover 위치/화살표 정렬 개선

### Out of Scope
- 상태 데이터/콘텐츠 변경
- 헤더 전체 레이아웃 변경

## 테스트/검증
- 자동 검증
  - `pnpm -C apps/frontend build` PASS
- 수동 검증
  - Status hover 시 팝오버 위치가 트리거 중앙 기준으로 표시되는지 확인

## 리스크 및 대응
- 리스크: 작은 화면에서 팝오버 위치 미세 변경
- 대응: 기존 trigger/content 구조를 유지하고 placement만 조정
- 롤백: PR revert로 즉시 복귀 가능

## 리뷰 가이드
- 우선 확인 파일
  - `apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx`
- 확인 포인트
  - 팝오버가 `Status`에 가깝게 보이는지
  - 화살표 정렬이 자연스러운지

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] 기존 컨벤션 준수 확인
- [x] 관련 이슈 링크 확인
- [x] 빌드 통과
- [x] 브레이킹 변경 없음