### PR TITLE
feat: FTP 서버 1차 구현 및 상태 연동

### DIFF
--- a/apps/backend/config/config.dev.yaml
+++ b/apps/backend/config/config.dev.yaml
@@ -3,7 +3,7 @@ server:
   http_enabled: true
   webdav_enabled: true
   ftp_enabled: false
-  ftp_port: 21
+  ftp_port: 2121
   sftp_enabled: false
   sftp_port: 22
 database:

--- a/apps/backend/config/config.prod.yaml
+++ b/apps/backend/config/config.prod.yaml
@@ -1,5 +1,11 @@
 server:
-  port: 3000
+  port: "3000"
+  http_enabled: true
+  webdav_enabled: true
+  ftp_enabled: false
+  ftp_port: 2121
+  sftp_enabled: false
+  sftp_port: 22
 database:
   url: data/cohesion.db
   user: test

--- a/apps/backend/go.mod
+++ b/apps/backend/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9 // indirect
+	github.com/goftp/server v0.0.0-20200708154336-f64f7c2d8a42 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/apps/backend/go.sum
+++ b/apps/backend/go.sum
@@ -14,6 +14,10 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9 h1:cC0Hbb+18DJ4i6ybqDybvj4wdIDS4vnD0QEci98PgM8=
+github.com/goftp/file-driver v0.0.0-20180502053751-5d604a0fc0c9/go.mod h1:GpOj6zuVBG3Inr9qjEnuVTgBlk2lZ1S9DcoFiXWyKss=
+github.com/goftp/server v0.0.0-20200708154336-f64f7c2d8a42 h1:JdOp2qR5PF4O75tzHeqrwnDDv8oHDptWyTbyYS4fD8E=
+github.com/goftp/server v0.0.0-20200708154336-f64f7c2d8a42/go.mod h1:k/SS6VWkxY7dHPhoMQ8IdRu8L4lQtmGbhyXGg+vCnXE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/apps/backend/internal/ftp/driver.go
+++ b/apps/backend/internal/ftp/driver.go
@@ -1,0 +1,438 @@
+package ftp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	goftp "github.com/goftp/server"
+	"taeu.kr/cohesion/internal/space"
+)
+
+type driverFactory struct {
+	spaceService *space.Service
+}
+
+func (f *driverFactory) NewDriver() (goftp.Driver, error) {
+	return &spaceDriver{
+		spaceService: f.spaceService,
+		perm:         goftp.NewSimplePerm("cohesion", "cohesion"),
+	}, nil
+}
+
+type spaceDriver struct {
+	spaceService *space.Service
+	perm         goftp.Perm
+}
+
+func (d *spaceDriver) Init(*goftp.Conn) {}
+
+func (d *spaceDriver) Stat(virtualPath string) (goftp.FileInfo, error) {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	if cleanPath == "/" {
+		return newVirtualDirInfo("/", "cohesion", "cohesion", time.Now()), nil
+	}
+
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+
+	spaceObj, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return nil, err
+	}
+
+	name := info.Name()
+	if relPath == "" {
+		name = spaceObj.SpaceName
+	}
+	return d.wrapFileInfo(cleanPath, info, name)
+}
+
+func (d *spaceDriver) ChangeDir(virtualPath string) error {
+	fileInfo, err := d.Stat(virtualPath)
+	if err != nil {
+		return err
+	}
+	if !fileInfo.IsDir() {
+		return errors.New("not a directory")
+	}
+	return nil
+}
+
+func (d *spaceDriver) ListDir(virtualPath string, callback func(goftp.FileInfo) error) error {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	if cleanPath == "/" {
+		spaces, err := d.spaceService.GetAllSpaces(context.Background())
+		if err != nil {
+			return err
+		}
+
+		for _, sp := range spaces {
+			mod := time.Now()
+			if stat, err := os.Stat(sp.SpacePath); err == nil {
+				mod = stat.ModTime()
+			}
+			if err := callback(newVirtualDirInfo(sp.SpaceName, "cohesion", "cohesion", mod)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return err
+	}
+	_, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(absPath)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		entryVirtual := path.Join(cleanPath, entry.Name())
+		wrapped, err := d.wrapFileInfo(entryVirtual, info, info.Name())
+		if err != nil {
+			return err
+		}
+		if err := callback(wrapped); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *spaceDriver) DeleteDir(virtualPath string) error {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	if cleanPath == "/" {
+		return os.ErrPermission
+	}
+
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return err
+	}
+	if relPath == "" {
+		return os.ErrPermission
+	}
+
+	_, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("not a directory")
+	}
+
+	return os.Remove(absPath)
+}
+
+func (d *spaceDriver) DeleteFile(virtualPath string) error {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return err
+	}
+	if relPath == "" {
+		return os.ErrPermission
+	}
+
+	_, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return errors.New("not a file")
+	}
+
+	return os.Remove(absPath)
+}
+
+func (d *spaceDriver) Rename(fromPath string, toPath string) error {
+	fromClean := normalizeVirtualPath(fromPath)
+	toClean := normalizeVirtualPath(toPath)
+
+	fromSpace, fromRel, err := splitVirtualPath(fromClean)
+	if err != nil {
+		return err
+	}
+	toSpace, toRel, err := splitVirtualPath(toClean)
+	if err != nil {
+		return err
+	}
+
+	if fromSpace != toSpace || fromRel == "" || toRel == "" {
+		return os.ErrPermission
+	}
+
+	_, absFrom, err := d.resolveAbsPath(fromSpace, fromRel)
+	if err != nil {
+		return err
+	}
+	_, absTo, err := d.resolveAbsPath(toSpace, toRel)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(absFrom, absTo)
+}
+
+func (d *spaceDriver) MakeDir(virtualPath string) error {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return err
+	}
+	if relPath == "" {
+		return os.ErrPermission
+	}
+
+	_, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return err
+	}
+
+	return os.MkdirAll(absPath, 0755)
+}
+
+func (d *spaceDriver) GetFile(virtualPath string, offset int64) (int64, io.ReadCloser, error) {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return 0, nil, err
+	}
+	if relPath == "" {
+		return 0, nil, os.ErrPermission
+	}
+
+	_, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	file, err := os.Open(absPath)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return 0, nil, err
+	}
+	if info.IsDir() {
+		file.Close()
+		return 0, nil, errors.New("not a file")
+	}
+
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		file.Close()
+		return 0, nil, err
+	}
+
+	return info.Size(), file, nil
+}
+
+func (d *spaceDriver) PutFile(virtualPath string, data io.Reader, appendData bool) (int64, error) {
+	cleanPath := normalizeVirtualPath(virtualPath)
+	spaceName, relPath, err := splitVirtualPath(cleanPath)
+	if err != nil {
+		return 0, err
+	}
+	if relPath == "" {
+		return 0, os.ErrPermission
+	}
+
+	spaceObj, absPath, err := d.resolveAbsPath(spaceName, relPath)
+	if err != nil {
+		return 0, err
+	}
+
+	parent := filepath.Dir(absPath)
+	if !isPathWithinSpace(parent, spaceObj.SpacePath) {
+		return 0, os.ErrPermission
+	}
+	if info, err := os.Stat(parent); err != nil || !info.IsDir() {
+		return 0, os.ErrNotExist
+	}
+
+	flags := os.O_CREATE | os.O_WRONLY
+	if appendData {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+
+	file, err := os.OpenFile(absPath, flags, 0644)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	written, err := io.Copy(file, data)
+	if err != nil {
+		return 0, err
+	}
+	return written, nil
+}
+
+func (d *spaceDriver) resolveAbsPath(spaceName, relativePath string) (*space.Space, string, error) {
+	spaceObj, err := d.spaceService.GetSpaceByName(context.Background(), spaceName)
+	if err != nil {
+		return nil, "", os.ErrNotExist
+	}
+
+	absPath := spaceObj.SpacePath
+	if relativePath != "" {
+		absPath = filepath.Join(spaceObj.SpacePath, filepath.FromSlash(relativePath))
+	}
+	if !isPathWithinSpace(absPath, spaceObj.SpacePath) {
+		return nil, "", os.ErrPermission
+	}
+
+	return spaceObj, absPath, nil
+}
+
+func (d *spaceDriver) wrapFileInfo(virtualPath string, info os.FileInfo, name string) (goftp.FileInfo, error) {
+	mode, err := d.perm.GetMode(virtualPath)
+	if err != nil {
+		return nil, err
+	}
+	owner, err := d.perm.GetOwner(virtualPath)
+	if err != nil {
+		return nil, err
+	}
+	group, err := d.perm.GetGroup(virtualPath)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		mode |= os.ModeDir
+	}
+
+	return &virtualFileInfo{
+		FileInfo: info,
+		name:     name,
+		mode:     mode,
+		owner:    owner,
+		group:    group,
+	}, nil
+}
+
+func normalizeVirtualPath(p string) string {
+	p = strings.ReplaceAll(p, "\\", "/")
+	cleaned := path.Clean("/" + strings.TrimPrefix(p, "/"))
+	if cleaned == "." {
+		return "/"
+	}
+	return cleaned
+}
+
+func splitVirtualPath(cleanPath string) (spaceName string, relativePath string, err error) {
+	if cleanPath == "/" {
+		return "", "", os.ErrPermission
+	}
+
+	trimmed := strings.TrimPrefix(cleanPath, "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return "", "", os.ErrInvalid
+	}
+
+	spaceName = parts[0]
+	if len(parts) > 1 {
+		relativePath = path.Clean(path.Join(parts[1:]...))
+		if relativePath == "." {
+			relativePath = ""
+		}
+	}
+	return spaceName, relativePath, nil
+}
+
+func isPathWithinSpace(pathValue, spacePath string) bool {
+	cleanPath := filepath.Clean(pathValue)
+	cleanSpace := filepath.Clean(spacePath)
+
+	rel, err := filepath.Rel(cleanSpace, cleanPath)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || !strings.HasPrefix(rel, "..")
+}
+
+type virtualFileInfo struct {
+	os.FileInfo
+	name  string
+	mode  os.FileMode
+	owner string
+	group string
+}
+
+func (f *virtualFileInfo) Name() string {
+	return f.name
+}
+
+func (f *virtualFileInfo) Mode() os.FileMode {
+	return f.mode
+}
+
+func (f *virtualFileInfo) Owner() string {
+	return f.owner
+}
+
+func (f *virtualFileInfo) Group() string {
+	return f.group
+}
+
+type staticDirInfo struct {
+	name    string
+	modTime time.Time
+}
+
+func (i *staticDirInfo) Name() string       { return i.name }
+func (i *staticDirInfo) Size() int64        { return 0 }
+func (i *staticDirInfo) Mode() os.FileMode  { return os.ModeDir | 0755 }
+func (i *staticDirInfo) ModTime() time.Time { return i.modTime }
+func (i *staticDirInfo) IsDir() bool        { return true }
+func (i *staticDirInfo) Sys() interface{}   { return nil }
+
+func newVirtualDirInfo(name, owner, group string, mod time.Time) goftp.FileInfo {
+	return &virtualFileInfo{
+		FileInfo: &staticDirInfo{name: name, modTime: mod},
+		name:     name,
+		mode:     os.ModeDir | 0755,
+		owner:    owner,
+		group:    group,
+	}
+}

--- a/apps/backend/internal/ftp/logger.go
+++ b/apps/backend/internal/ftp/logger.go
@@ -1,0 +1,33 @@
+package ftp
+
+import "github.com/rs/zerolog/log"
+
+type ftpLogger struct{}
+
+func (l *ftpLogger) Print(sessionID string, message interface{}) {
+	log.Debug().Str("session_id", sessionID).Interface("message", message).Msg("[FTP]")
+}
+
+func (l *ftpLogger) Printf(sessionID string, format string, v ...interface{}) {
+	log.Debug().Str("session_id", sessionID).Msgf("[FTP] "+format, v...)
+}
+
+func (l *ftpLogger) PrintCommand(sessionID string, command string, params string) {
+	if command == "PASS" {
+		log.Debug().Str("session_id", sessionID).Str("command", command).Msg("[FTP] command")
+		return
+	}
+	log.Debug().
+		Str("session_id", sessionID).
+		Str("command", command).
+		Str("params", params).
+		Msg("[FTP] command")
+}
+
+func (l *ftpLogger) PrintResponse(sessionID string, code int, message string) {
+	log.Debug().
+		Str("session_id", sessionID).
+		Int("code", code).
+		Str("message", message).
+		Msg("[FTP] response")
+}

--- a/apps/backend/internal/ftp/service.go
+++ b/apps/backend/internal/ftp/service.go
@@ -1,0 +1,123 @@
+package ftp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	goftp "github.com/goftp/server"
+	"github.com/rs/zerolog/log"
+	"taeu.kr/cohesion/internal/space"
+)
+
+const (
+	defaultFTPPort     = 2121
+	defaultFTPUser     = "cohesion"
+	defaultFTPPassword = "cohesion"
+)
+
+type Service struct {
+	spaceService *space.Service
+	server       *goftp.Server
+	enabled      bool
+	port         int
+	username     string
+	password     string
+	running      bool
+	mu           sync.RWMutex
+}
+
+func NewService(spaceService *space.Service, enabled bool, port int) *Service {
+	if port <= 0 {
+		port = defaultFTPPort
+	}
+
+	username := os.Getenv("COHESION_FTP_USER")
+	if username == "" {
+		username = defaultFTPUser
+	}
+
+	password := os.Getenv("COHESION_FTP_PASSWORD")
+	if password == "" {
+		password = defaultFTPPassword
+	}
+
+	return &Service{
+		spaceService: spaceService,
+		enabled:      enabled,
+		port:         port,
+		username:     username,
+		password:     password,
+	}
+}
+
+func (s *Service) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.enabled {
+		s.running = false
+		return nil
+	}
+	if s.running {
+		return nil
+	}
+
+	opts := &goftp.ServerOpts{
+		Factory:        &driverFactory{spaceService: s.spaceService},
+		Port:           s.port,
+		Hostname:       "0.0.0.0",
+		Name:           "Cohesion FTP",
+		WelcomeMessage: "Cohesion FTP",
+		Auth:           &goftp.SimpleAuth{Name: s.username, Password: s.password},
+		Logger:         &ftpLogger{},
+	}
+
+	ftpServer := goftp.NewServer(opts)
+	errCh := make(chan error, 1)
+
+	go func() {
+		if err := ftpServer.ListenAndServe(); err != nil && !errors.Is(err, goftp.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("failed to start ftp server on port %d: %w", s.port, err)
+	case <-time.After(200 * time.Millisecond):
+		s.server = ftpServer
+		s.running = true
+		log.Info().Msgf("[FTP] server started on port %d (user: %s)", s.port, s.username)
+		return nil
+	}
+}
+
+func (s *Service) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.server == nil {
+		s.running = false
+		return nil
+	}
+
+	if err := s.server.Shutdown(); err != nil {
+		return err
+	}
+
+	s.server = nil
+	s.running = false
+	log.Info().Msg("[FTP] server stopped")
+	return nil
+}
+
+func (s *Service) Enabled() bool {
+	return s.enabled
+}
+
+func (s *Service) Port() int {
+	return s.port
+}

--- a/apps/backend/internal/status/handler.go
+++ b/apps/backend/internal/status/handler.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
+	"taeu.kr/cohesion/internal/config"
 	"taeu.kr/cohesion/internal/platform/web"
 	"taeu.kr/cohesion/internal/space"
 )
@@ -59,12 +61,7 @@ func (h *Handler) handleStatus(w http.ResponseWriter, r *http.Request) *web.Erro
 	// WebDAV (Space 조회 가능 여부)
 	protocols["webdav"] = h.checkWebDAV()
 
-	// FTP (미구현)
-	protocols["ftp"] = ProtocolStatus{
-		Status:  "unavailable",
-		Message: "미구현",
-		Port:    "21",
-	}
+	protocols["ftp"] = h.checkFTP()
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(StatusResponse{
@@ -113,6 +110,40 @@ func (h *Handler) checkWebDAV() ProtocolStatus {
 		Message: "정상",
 		Port:    h.port,
 		Path:    "/dav/",
+	}
+}
+
+func (h *Handler) checkFTP() ProtocolStatus {
+	if !config.Conf.Server.FtpEnabled {
+		return ProtocolStatus{
+			Status:  "unavailable",
+			Message: "비활성화",
+			Port:    strconv.Itoa(config.Conf.Server.FtpPort),
+		}
+	}
+
+	if config.Conf.Server.FtpPort <= 0 {
+		return ProtocolStatus{
+			Status:  "unhealthy",
+			Message: "포트 설정 오류",
+		}
+	}
+
+	port := strconv.Itoa(config.Conf.Server.FtpPort)
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", port), 1500*time.Millisecond)
+	if err != nil {
+		return ProtocolStatus{
+			Status:  "unhealthy",
+			Message: "연결 실패",
+			Port:    port,
+		}
+	}
+	_ = conn.Close()
+
+	return ProtocolStatus{
+		Status:  "healthy",
+		Message: "정상",
+		Port:    port,
 	}
 }
 

--- a/apps/frontend/src/pages/Settings/sections/ServerSettings.tsx
+++ b/apps/frontend/src/pages/Settings/sections/ServerSettings.tsx
@@ -263,14 +263,7 @@ const ServerSettings = () => {
       <Card title="FTP 서버" size="small">
         <Space vertical size="small" className="settings-stack-full">
           <SettingRow
-            left={(
-              <div>
-                <Text strong>활성화</Text>
-                <Text type="secondary" className="settings-inline-note">
-                  (구현 예정)
-                </Text>
-              </div>
-            )}
+            left={<Text strong>활성화</Text>}
             right={(
               <Switch
                 checked={server.ftpEnabled}

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,17 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **FTP 서버 1차 구현 완료** (2026-02-16, #70):
+    - 백엔드 `internal/ftp` 모듈 신설:
+      - Space 기반 가상 루트 드라이버(`/{spaceName}/...`) 구현.
+      - FTP start/stop 서비스 및 인증(`COHESION_FTP_USER`, `COHESION_FTP_PASSWORD`, 기본 `cohesion/cohesion`) 적용.
+    - `main.go` 재시작 lifecycle에 FTP 서버 기동/종료 연동.
+    - 상태 API `/api/status`의 FTP 항목을 하드코딩 `미구현`에서 실제 TCP 연결 기반 헬스체크로 전환.
+    - 설정 파일 기본 포트 정리:
+      - `config.dev.yaml`: `ftp_port: 2121`
+      - `config.prod.yaml`: `http/webdav/ftp/sftp` 기본 키 추가 및 `ftp_port: 2121`
+    - 프론트 Settings FTP UI의 `(구현 예정)` 문구 제거.
+    - 검증: `go test ./...` (apps/backend), `pnpm -C apps/frontend build` 통과.
 - **Settings 잔여 인라인 스타일 공통 클래스화 완료** (2026-02-16):
     - `settings.css`에 공통 유틸 클래스(`settings-nav-menu-full`, `settings-select-*`, `settings-divider-compact`, `settings-port-input` 등) 추가.
     - `GeneralSettings`, `FileSettings`, `ServerSettings`의 반복 인라인 스타일을 공통 클래스로 치환.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -94,3 +94,4 @@
 - [x] 공통 헤더 컴포넌트(`HeaderBrand`, `HeaderGroup`) 도입 및 메인/세팅 적용
 - [x] Settings 잔여 인라인 스타일(`Select/Divider/InputNumber/Alert`) 공통 클래스화
 - [x] MainLayout/MainSider 잔여 인라인 스타일 공통 클래스화 (`layout-content-scroll-hidden`, `layout-sider-title`)
+- [x] FTP 서버 1차 구현 (Space 가상 루트, start/stop lifecycle, status 연동) (#70)


### PR DESCRIPTION
## 목적
- 설정에만 존재하던 FTP 항목을 실제 서버 기능으로 연결합니다.
- `/api/status`에서 FTP 상태를 실제 기동 상태로 표시합니다.

## 변경 사항
- 백엔드 FTP 모듈 추가 (`internal/ftp`)
  - Space 가상 루트 드라이버 구현: `/{spaceName}/...`
  - Space 외부 경로 접근 차단
  - FTP 서버 start/stop 서비스 및 로그 어댑터 추가
- 서버 lifecycle 연동
  - `main` 재시작 루프에 FTP start/stop 연결
  - `ftpEnabled`, `ftpPort` 설정 반영
- 상태 API 개선
  - FTP 항목을 하드코딩 `미구현` -> 실제 TCP 헬스체크 기반 반환
- 설정/UX 정리
  - `config.dev.yaml`, `config.prod.yaml` FTP 기본 포트 `2121` 정리
  - Settings > 서버 > FTP의 `(구현 예정)` 문구 제거
- 문서 동기화
  - `docs/ai-context/status.md`
  - `docs/ai-context/todo.md`
  - `docs/ai-context/decision_log.md`

## 검증
- `cd apps/backend && go test ./...` 통과
- `pnpm -C apps/frontend build` 통과

## 운영 메모
- 기본 FTP 계정: `cohesion / cohesion`
- 환경변수로 덮어쓰기 가능:
  - `COHESION_FTP_USER`
  - `COHESION_FTP_PASSWORD`

Closes #70