### PR TITLE
feat: 테이블 뷰 리스트형 UX로 전환 및 정렬 노출 통일

### DIFF
--- a/apps/frontend/src/features/browse/components/FolderContent.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Empty, App, Grid, Button, Drawer, Menu, theme } from 'antd';
 import { DownloadOutlined, CopyOutlined, DeleteOutlined, EditOutlined, CloseOutlined, MoreOutlined } from '@ant-design/icons';
 import { useBrowseStore } from '@/stores/browseStore';
 import type { FileNode, ViewMode, SortConfig } from '../types';
-import { buildTableColumns } from '../constants';
 import { useFileSelection } from '../hooks/useFileSelection';
 import { useBreadcrumb } from '../hooks/useBreadcrumb';
 import { useFileOperations } from '../hooks/useFileOperations';
@@ -161,9 +160,6 @@ const FolderContent: React.FC = () => {
   const sortedContent = useSortedContent(content, sortConfig);
   const isAnyModalOpen =
     modals.destination.visible || modals.rename.visible || modals.createFolder.visible;
-
-  // Columns for table view
-  const columns = useMemo(() => buildTableColumns(setPath, sortConfig), [setPath, sortConfig]);
 
   // Box selection (Grid 뷰 전용)
   const { isSelecting, selectionBox, wasRecentlySelecting } = useBoxSelection({
@@ -562,11 +558,9 @@ const FolderContent: React.FC = () => {
         >
           <FolderContentTable
             dataSource={sortedContent}
-            columns={columns}
             loading={isLoading}
             selectedItems={selectedItems}
             dragOverFolder={dragOverFolder}
-            onSelectionChange={setSelection}
             onItemClick={handleItemTap}
             onItemDoubleClick={setPath}
             onItemTouchStart={(record) => handleMobileLongPressStart(record)}
@@ -578,11 +572,13 @@ const FolderContent: React.FC = () => {
             onFolderDragOver={handleFolderDragOver}
             onFolderDragLeave={handleFolderDragLeave}
             onFolderDrop={handleFolderDrop}
-            sortConfig={sortConfig}
-            onSortChange={setSortConfig}
-            isMobile={isMobile}
-            isSelectionMode={isMobileSelectionMode}
             disableDrag={isMobile || !canWriteFiles}
+            canWriteFiles={canWriteFiles}
+            onItemDownload={(record) => handleBulkDownload([record.path])}
+            onItemCopy={(record) => openModal('destination', { mode: 'copy', sources: [record.path] })}
+            onItemMove={(record) => openModal('destination', { mode: 'move', sources: [record.path] })}
+            onItemRename={(record) => openModal('rename', { record, newName: record.name })}
+            onItemDelete={handleDelete}
           />
         </div>
       ) : (

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { Table } from 'antd';
-import type { TableColumnsType } from 'antd';
-import type { FileNode, SortConfig } from '../../types';
+import { Table, Dropdown, Button } from 'antd';
+import type { MenuProps } from 'antd';
+import { FolderFilled, FileOutlined, MoreOutlined, EditOutlined, DeleteOutlined, CopyOutlined, DownloadOutlined } from '@ant-design/icons';
+import type { FileNode } from '../../types';
+import { formatDate } from '../../constants';
 
 interface FolderContentTableProps {
   dataSource: FileNode[];
-  columns: TableColumnsType<FileNode>;
   loading: boolean;
   selectedItems: Set<string>;
   dragOverFolder: string | null;
-  onSelectionChange: (items: Set<string>) => void;
   onItemClick: (e: React.MouseEvent<HTMLElement>, record: FileNode, index: number) => void;
   onItemDoubleClick: (path: string) => void;
   onItemTouchStart?: (record: FileNode, index: number) => void;
@@ -21,20 +21,20 @@ interface FolderContentTableProps {
   onFolderDragOver: (e: React.DragEvent<HTMLElement>, record: FileNode) => void;
   onFolderDragLeave: (e: React.DragEvent<HTMLElement>) => void;
   onFolderDrop: (e: React.DragEvent<HTMLElement>, record: FileNode) => void;
-  sortConfig: SortConfig;
-  onSortChange: (config: SortConfig) => void;
-  isMobile?: boolean;
-  isSelectionMode?: boolean;
   disableDrag?: boolean;
+  canWriteFiles: boolean;
+  onItemDownload: (record: FileNode) => void;
+  onItemCopy: (record: FileNode) => void;
+  onItemMove: (record: FileNode) => void;
+  onItemRename: (record: FileNode) => void;
+  onItemDelete: (record: FileNode) => void;
 }
 
 const FolderContentTable: React.FC<FolderContentTableProps> = ({
   dataSource,
-  columns,
   loading,
   selectedItems,
   dragOverFolder,
-  onSelectionChange,
   onItemClick,
   onItemDoubleClick,
   onItemTouchStart,
@@ -46,11 +46,100 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
   onFolderDragOver,
   onFolderDragLeave,
   onFolderDrop,
-  onSortChange,
-  isMobile = false,
-  isSelectionMode = false,
   disableDrag = false,
+  canWriteFiles,
+  onItemDownload,
+  onItemCopy,
+  onItemMove,
+  onItemRename,
+  onItemDelete,
 }) => {
+  const columns = [
+    {
+      key: 'entry',
+      dataIndex: 'name',
+      render: (_: string, record: FileNode) => {
+        const menuItems: MenuProps['items'] = [
+          {
+            key: 'download',
+            icon: <DownloadOutlined />,
+            label: record.isDir ? '폴더 다운로드 (ZIP)' : '다운로드',
+          },
+          ...(canWriteFiles
+            ? [
+                {
+                  key: 'copy',
+                  icon: <CopyOutlined />,
+                  label: '복사',
+                },
+                {
+                  key: 'move',
+                  icon: (
+                    <span className="material-symbols-rounded" style={{ fontSize: 18, lineHeight: 1, fontVariationSettings: '"FILL" 1, "wght" 500, "GRAD" 0, "opsz" 20' }}>
+                      drive_file_move
+                    </span>
+                  ),
+                  label: '이동',
+                },
+                {
+                  key: 'rename',
+                  icon: <EditOutlined />,
+                  label: '이름 변경',
+                },
+                { type: 'divider' as const },
+                {
+                  key: 'delete',
+                  icon: <DeleteOutlined />,
+                  label: '삭제',
+                  danger: true,
+                },
+              ]
+            : []),
+        ];
+
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, width: '100%' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
+              {record.isDir ? <FolderFilled style={{ color: '#ffca28', fontSize: 18 }} /> : <FileOutlined style={{ fontSize: 18 }} />}
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontWeight: 500, color: 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {record.name}
+                </div>
+                <div style={{ fontSize: 12, opacity: 0.72 }}>
+                  {formatDate(record.modTime)}
+                </div>
+              </div>
+            </div>
+            <Dropdown
+              trigger={['click']}
+              placement="bottomRight"
+              menu={{
+                items: menuItems,
+                onClick: ({ key, domEvent }) => {
+                  domEvent.stopPropagation();
+                  if (key === 'download') onItemDownload(record);
+                  if (key === 'copy') onItemCopy(record);
+                  if (key === 'move') onItemMove(record);
+                  if (key === 'rename') onItemRename(record);
+                  if (key === 'delete') onItemDelete(record);
+                },
+              }}
+            >
+              <Button
+                type="text"
+                size="small"
+                icon={<MoreOutlined />}
+                onClick={(e) => e.stopPropagation()}
+                aria-label="더보기"
+                title="더보기"
+              />
+            </Dropdown>
+          </div>
+        );
+      },
+    },
+  ];
+
   return (
     <Table
       dataSource={dataSource}
@@ -58,20 +147,8 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
       loading={loading}
       rowKey="path"
       pagination={false}
-      rowSelection={isMobile && !isSelectionMode ? undefined : {
-        type: 'checkbox',
-        selectedRowKeys: Array.from(selectedItems),
-        onChange: (keys) => onSelectionChange(new Set(keys as string[])),
-      }}
-      onChange={(_, __, sorter) => {
-        if (sorter && !Array.isArray(sorter)) {
-          const field = sorter.field as 'name' | 'modTime' | 'size';
-          const order = sorter.order as 'ascend' | 'descend' | undefined;
-          if (field && order) {
-            onSortChange({ sortBy: field, sortOrder: order });
-          }
-        }
-      }}
+      showHeader={false}
+      rowClassName={(record) => (selectedItems.has(record.path) ? 'folder-content-row-selected' : '')}
       onRow={(record: FileNode, index?: number) => ({
         onClick: (e: React.MouseEvent<HTMLElement>) => onItemClick(e, record, index ?? 0),
         onDoubleClick: () => record.isDir && onItemDoubleClick(record.path),
@@ -87,8 +164,13 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
         onDragLeave: disableDrag ? undefined : (e: React.DragEvent<HTMLElement>) => record.isDir && onFolderDragLeave(e),
         onDrop: disableDrag ? undefined : (e: React.DragEvent<HTMLElement>) => record.isDir && onFolderDrop(e, record),
         style: {
-          backgroundColor: dragOverFolder === record.path ? 'rgba(24, 144, 255, 0.1)' : undefined,
+          backgroundColor: dragOverFolder === record.path
+            ? 'rgba(24, 144, 255, 0.1)'
+            : selectedItems.has(record.path)
+              ? 'rgba(24, 144, 255, 0.08)'
+              : undefined,
           userSelect: 'none',
+          cursor: 'default',
         } as React.CSSProperties,
       })}
       locale={{ emptyText: '이 폴더는 비어 있습니다.' }}

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentToolbar.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentToolbar.tsx
@@ -46,21 +46,19 @@ const FolderContentToolbar: React.FC<FolderContentToolbarProps> = ({
             title="업로드"
           />
         )}
-        {viewMode === 'grid' && (
-          <Select
-            popupMatchSelectWidth={false}
-            style={{ width: 'fit-content' }}
-            value={`${sortConfig.sortBy}-${sortConfig.sortOrder}`}
-            onChange={(value: string) => {
-              const [sortBy, sortOrder] = value.split('-') as [
-                'name' | 'modTime' | 'size',
-                'ascend' | 'descend'
-              ];
-              onSortChange({ sortBy, sortOrder });
-            }}
-            options={SORT_OPTIONS}
-          />
-        )}
+        <Select
+          popupMatchSelectWidth={false}
+          style={{ width: 'fit-content' }}
+          value={`${sortConfig.sortBy}-${sortConfig.sortOrder}`}
+          onChange={(value: string) => {
+            const [sortBy, sortOrder] = value.split('-') as [
+              'name' | 'modTime' | 'size',
+              'ascend' | 'descend'
+            ];
+            onSortChange({ sortBy, sortOrder });
+          }}
+          options={SORT_OPTIONS}
+        />
         <AntSpace.Compact>
           <Button
             icon={<UnorderedListOutlined />}


### PR DESCRIPTION
## 변경 사항
- 테이블 뷰 헤더 제거 (`showHeader=false`)
- 정렬 셀렉트 박스를 테이블/그리드 공통 노출로 통일
- 테이블 행 UI를 리스트형으로 변경
  - 좌측: 파일/폴더 아이콘
  - 중앙: 이름 + 하단 수정일
  - 우측: `:` 더보기 메뉴
- 더보기 메뉴에 다운로드/복사/이동/이름 변경/삭제 액션 연결

## 검증
- `cd apps/frontend && pnpm exec tsc --noEmit` 통과

## 참고
- 사용자 요청 기반 UX 반영 (모바일/PC 공통 테이블 표현 단순화)