### PR TITLE
refactor: 설정/메인 패널 헤더 및 드로어 구조 공통화

### DIFF
--- a/apps/frontend/src/assets/css/global.css
+++ b/apps/frontend/src/assets/css/global.css
@@ -88,9 +88,26 @@ html, body {
 
 .layout-sider-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
   padding: 16px;
+  min-height: 56px;
+  border-bottom: 1px solid var(--ant-colorBorder);
+  color: var(--ant-colorText);
+}
+
+.layout-sider-header-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.layout-sider-header-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
 }
 
 .layout-sider-body {
@@ -120,6 +137,7 @@ html, body {
   font-size: 14px;
   font-weight: 600;
   line-height: 1;
+  min-width: 0;
 }
 
 .app-drawer .ant-drawer-body {
@@ -128,4 +146,17 @@ html, body {
 
 .app-drawer--no-header .ant-drawer-header {
   display: none;
+}
+
+.app-drawer--nav .ant-drawer-content,
+.app-drawer--nav .ant-drawer-body {
+  background: var(--ant-colorBgContainer);
+}
+
+.panel-close-btn.ant-btn-text,
+.panel-close-btn.ant-btn-text:hover,
+.panel-close-btn.ant-btn-text:active,
+.panel-close-btn.ant-btn-text:focus,
+.panel-close-btn.ant-btn-text:focus-visible {
+  background: transparent !important;
 }

--- a/apps/frontend/src/assets/css/settings.css
+++ b/apps/frontend/src/assets/css/settings.css
@@ -15,10 +15,6 @@
   border-right: 0 !important;
 }
 
-.settings-icon-lg {
-  font-size: 20px;
-}
-
 .settings-section {
   width: 100%;
 }

--- a/apps/frontend/src/components/common/HeaderBrand.tsx
+++ b/apps/frontend/src/components/common/HeaderBrand.tsx
@@ -4,13 +4,38 @@ interface HeaderBrandProps {
   text: string;
   color?: string;
   className?: string;
+  onClick?: () => void;
+  ariaLabel?: string;
+  title?: string;
 }
 
-const HeaderBrand: React.FC<HeaderBrandProps> = ({ text, color, className }) => {
+const HeaderBrand: React.FC<HeaderBrandProps> = ({ text, color, className, onClick, ariaLabel, title }) => {
+  const interactiveProps = onClick
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick,
+        onKeyDown: (event: React.KeyboardEvent<HTMLSpanElement>) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick();
+          }
+        },
+        'aria-label': ariaLabel,
+        title,
+        style: {
+          ...(color ? { color } : {}),
+          cursor: 'pointer',
+        },
+      }
+    : {
+        style: color ? { color } : undefined,
+      };
+
   return (
     <span
       className={`layout-header-brand${className ? ` ${className}` : ''}`}
-      style={color ? { color } : undefined}
+      {...interactiveProps}
     >
       {text}
     </span>

--- a/apps/frontend/src/components/common/SidePanelShell.tsx
+++ b/apps/frontend/src/components/common/SidePanelShell.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface SidePanelShellProps {
+  title: string;
+  leftAction?: React.ReactNode;
+  rightAction?: React.ReactNode;
+  bodyClassName?: string;
+  children: React.ReactNode;
+}
+
+const SidePanelShell: React.FC<SidePanelShellProps> = ({
+  title,
+  leftAction,
+  rightAction,
+  bodyClassName,
+  children,
+}) => {
+  return (
+    <>
+      <div className="layout-sider-header">
+        <div className="layout-sider-header-main">
+          {leftAction ? <div className="layout-sider-header-action">{leftAction}</div> : null}
+          <span className="layout-sider-title">{title}</span>
+        </div>
+        {rightAction ? <div className="layout-sider-header-action">{rightAction}</div> : null}
+      </div>
+      <div className={`layout-sider-body${bodyClassName ? ` ${bodyClassName}` : ''}`}>
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default SidePanelShell;

--- a/apps/frontend/src/components/layout/MainLayout/MainSider.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/MainSider.tsx
@@ -6,6 +6,7 @@ import type { Space } from "@/features/space/types";
 import { useState } from "react";
 import { useSpaceStore } from "@/stores/spaceStore";
 import { useAuth } from "@/features/auth/useAuth";
+import SidePanelShell from "@/components/common/SidePanelShell";
 
 const { Sider } = Layout;
 
@@ -57,12 +58,11 @@ export default function MainSider({ onPathSelect, onAfterSelect, onClosePanel, c
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
       />
-      <div
-        className="layout-sider-header"
-        style={{ borderBottom: `1px solid ${token.colorBorder}`, color: token.colorText }}
-      >
-        {containerType === "panel" && (
+      <SidePanelShell
+        title="Spaces"
+        leftAction={containerType === "panel" ? (
           <Button
+            className="panel-close-btn"
             type="text"
             icon={<CloseOutlined />}
             size="small"
@@ -70,25 +70,23 @@ export default function MainSider({ onPathSelect, onAfterSelect, onClosePanel, c
             aria-label="탐색 닫기"
             title="탐색 닫기"
           />
-        )}
-        <span className="layout-sider-title">Spaces</span>
-        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-          {canWriteSpaces && (
-            <Button
-              type="text"
-              icon={<PlusOutlined />}
-              size="small"
-              onClick={() => setIsOpen(true)}
-            />
-          )}
-        </div>
-      </div>
-      <div className="layout-sider-body">
+        ) : null}
+        rightAction={canWriteSpaces ? (
+          <Button
+            type="text"
+            icon={<PlusOutlined />}
+            size="small"
+            onClick={() => setIsOpen(true)}
+            aria-label="Space 추가"
+            title="Space 추가"
+          />
+        ) : null}
+      >
         <FolderTree
           onSelect={handleSelect}
           onSpaceDelete={canWriteSpaces ? handleDeleteSpace : undefined}
         />
-      </div>
+      </SidePanelShell>
     </>
   );
 

--- a/apps/frontend/src/pages/Settings/index.tsx
+++ b/apps/frontend/src/pages/Settings/index.tsx
@@ -7,8 +7,8 @@ import {
   GlobalOutlined,
   SafetyCertificateOutlined,
   TeamOutlined,
-  HomeFilled,
   MenuOutlined,
+  CloseOutlined,
 } from '@ant-design/icons';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -23,6 +23,7 @@ import PermissionSettings from './sections/PermissionSettings';
 import ProfileSettings from './sections/ProfileSettings';
 import HeaderBrand from '@/components/common/HeaderBrand';
 import HeaderGroup from '@/components/common/HeaderGroup';
+import SidePanelShell from '@/components/common/SidePanelShell';
 import '@/assets/css/settings.css';
 
 const { Sider, Content, Header } = Layout;
@@ -121,18 +122,19 @@ const SettingsPage = () => {
           {isMobile && (
             <Button
               type="text"
-              icon={<MenuOutlined className="settings-icon-lg" />}
+              icon={<MenuOutlined />}
               onClick={() => setIsNavOpen(true)}
               aria-label="설정 메뉴 열기"
               title="설정 메뉴"
             />
           )}
-          <Button
-            type="text"
-            icon={<HomeFilled className="settings-icon-lg" />}
+          <HeaderBrand
+            text="Cohesion"
+            color={token.colorText}
             onClick={() => navigate('/')}
+            ariaLabel="메인으로 이동"
+            title="메인으로 이동"
           />
-          <HeaderBrand text="설정" color={token.colorText} />
         </HeaderGroup>
       </Header>
 
@@ -145,13 +147,15 @@ const SettingsPage = () => {
               background: token.colorBgContainer,
             }}
           >
-            <Menu
-              className="settings-nav-menu settings-nav-menu-full"
-              mode="inline"
-              selectedKeys={[effectiveSection]}
-              items={menuItems}
-              onClick={({ key }: { key: string }) => setSelectedSection(key as SettingsSection)}
-            />
+            <SidePanelShell title="설정">
+              <Menu
+                className="settings-nav-menu settings-nav-menu-full"
+                mode="inline"
+                selectedKeys={[effectiveSection]}
+                items={menuItems}
+                onClick={({ key }: { key: string }) => setSelectedSection(key as SettingsSection)}
+              />
+            </SidePanelShell>
           </Sider>
         )}
 
@@ -165,23 +169,46 @@ const SettingsPage = () => {
         </Content>
 
         <Drawer
-          rootClassName="app-drawer app-drawer--settings-nav"
+          rootClassName="app-drawer app-drawer--no-header app-drawer--nav app-drawer--settings-nav"
           placement="left"
-          title="설정 메뉴"
           open={isMobile && isNavOpen}
           onClose={() => setIsNavOpen(false)}
           maskClosable
         >
-          <Menu
-            className="settings-nav-menu settings-nav-menu-full"
-            mode="inline"
-            selectedKeys={[effectiveSection]}
-            items={menuItems}
-            onClick={({ key }: { key: string }) => {
-              setSelectedSection(key as SettingsSection);
-              setIsNavOpen(false);
+          <div
+            className="layout-sider layout-sider-panel"
+            style={{
+              height: '100%',
+              width: '100%',
+              background: token.colorBgContainer,
             }}
-          />
+          >
+            <SidePanelShell
+              title="설정"
+              leftAction={(
+                <Button
+                  className="panel-close-btn"
+                  type="text"
+                  icon={<CloseOutlined />}
+                  size="small"
+                  onClick={() => setIsNavOpen(false)}
+                  aria-label="설정 메뉴 닫기"
+                  title="설정 메뉴 닫기"
+                />
+              )}
+            >
+              <Menu
+                className="settings-nav-menu settings-nav-menu-full"
+                mode="inline"
+                selectedKeys={[effectiveSection]}
+                items={menuItems}
+                onClick={({ key }: { key: string }) => {
+                  setSelectedSection(key as SettingsSection);
+                  setIsNavOpen(false);
+                }}
+              />
+            </SidePanelShell>
+          </div>
         </Drawer>
       </Layout>
     </Layout>


### PR DESCRIPTION
## 변경 사항
- `SidePanelShell` 공통 컴포넌트 추가
- `Spaces`/`설정` 사이드패널 헤더 구조를 동일한 공통 컴포넌트로 통합
- 설정 헤더의 브랜드 클릭 동작을 `HeaderBrand` 공통 인터랙션으로 이동
- 모바일 설정 Drawer를 메인과 같은 패널 래퍼(`layout-sider layout-sider-panel`) 경로로 통일
- 네비 Drawer 배경/헤더 처리 공통 클래스 정리
- 패널 닫기 버튼(`X`) 상태 스타일 일관화

## 검증
- `cd apps/frontend && pnpm exec tsc --noEmit` 통과
- 375 뷰포트 기준 설정/메인 Drawer 시각 비교 확인