### PR TITLE
fix: 테이블 선택 반응과 선택색상 공통화 개선

### DIFF
--- a/apps/frontend/src/assets/css/global.css
+++ b/apps/frontend/src/assets/css/global.css
@@ -1,5 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:FILL@0..1');
 
+:root {
+  --browse-selection-border-color: #1890ff;
+  --browse-selection-bg: rgba(24, 144, 255, 0.1);
+  --browse-dragover-bg: rgba(24, 144, 255, 0.05);
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
 }
@@ -159,6 +165,19 @@ html, body {
 .app-drawer--nav .ant-drawer-content,
 .app-drawer--nav .ant-drawer-body {
   background: var(--ant-colorBgContainer);
+}
+
+.folder-content-row {
+  user-select: none;
+  cursor: default;
+}
+
+.folder-content-row-selected > td {
+  background-color: var(--browse-selection-bg) !important;
+}
+
+.folder-content-row-dragover > td {
+  background-color: var(--browse-dragover-bg) !important;
 }
 
 .panel-close-btn.ant-btn-text,

--- a/apps/frontend/src/features/browse/components/FolderContent.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent.tsx
@@ -113,10 +113,12 @@ const FolderContent: React.FC = () => {
     selectedSpace,
     onNavigate: setPath,
   });
+  // 정렬된 콘텐츠 (폴더 우선 + sortConfig)
+  const sortedContent = useSortedContent(content, sortConfig);
 
   const { handleContextMenu, handleEmptyAreaContextMenu } = useContextMenu({
     selectedItems,
-    sortedContent: content,
+    sortedContent,
     canWriteFiles,
     onSetSelection: setSelection,
     callbacks: {
@@ -157,8 +159,6 @@ const FolderContent: React.FC = () => {
     prevNavRef.current = currentNav;
   }, [selectedPath, selectedSpace, handleClearSelection, modals.destination.visible]);
 
-  // 정렬된 콘텐츠 (폴더 우선 + sortConfig)
-  const sortedContent = useSortedContent(content, sortConfig);
   const isAnyModalOpen =
     modals.destination.visible || modals.rename.visible || modals.createFolder.visible;
 
@@ -401,10 +401,15 @@ const FolderContent: React.FC = () => {
     const isButton = target.closest('button');
     const isInput = target.closest('input');
     const isModalContent = target.closest('.ant-modal');
+    const isSelectionToolbar = target.closest('[data-selection-toolbar="true"]');
     const isMobileSelectionBar = target.closest('[data-mobile-selection-bar="true"]');
 
     // 모달 내부 클릭은 React portal 이벤트 버블링으로 들어오므로 선택 해제 대상에서 제외
     if (isModalContent) {
+      return;
+    }
+
+    if (isSelectionToolbar) {
       return;
     }
 
@@ -446,9 +451,11 @@ const FolderContent: React.FC = () => {
         onChange={handleFileSelect}
       />
 
-      <div data-selection-exclude="true" style={{ height: topRowHeight, marginTop: 8 }}>
+      <div style={{ height: topRowHeight, marginTop: 8 }}>
         {showMobileSelectionBar ? (
           <div
+            data-selection-toolbar="true"
+            data-selection-exclude="true"
             data-mobile-selection-bar="true"
             onClick={(e) => e.stopPropagation()}
             onTouchStart={(e) => e.stopPropagation()}
@@ -543,6 +550,8 @@ const FolderContent: React.FC = () => {
           </div>
         ) : showDesktopSelectionBar ? (
           <div
+            data-selection-toolbar="true"
+            data-selection-exclude="true"
             style={{
               display: 'flex',
               alignItems: 'center',
@@ -639,7 +648,7 @@ const FolderContent: React.FC = () => {
             onFolderDragOver={handleFolderDragOver}
             onFolderDragLeave={handleFolderDragLeave}
             onFolderDrop={handleFolderDrop}
-            disableDrag={isMobile || !canWriteFiles}
+            disableDrag
             canWriteFiles={canWriteFiles}
             onItemDownload={(record) => handleBulkDownload([record.path])}
             onItemCopy={(record) => openModal('destination', { mode: 'copy', sources: [record.path] })}

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx
@@ -94,14 +94,14 @@ const FolderContentGrid: React.FC<FolderContentGridProps> = ({
                   textAlign: 'center',
                   cursor: 'pointer',
                   border: isSelected
-                    ? '2px solid #1890ff'
+                    ? '2px solid var(--browse-selection-border-color)'
                     : dragOverFolder === item.path
-                      ? '2px dashed #1890ff'
+                      ? '2px dashed var(--browse-selection-border-color)'
                       : undefined,
                   backgroundColor: isSelected
-                    ? 'rgba(24, 144, 255, 0.1)'
+                    ? 'var(--browse-selection-bg)'
                     : dragOverFolder === item.path
-                      ? 'rgba(24, 144, 255, 0.05)'
+                      ? 'var(--browse-dragover-bg)'
                       : undefined,
                   userSelect: 'none',
                 }}

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx
@@ -149,7 +149,15 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
       rowKey="path"
       pagination={false}
       showHeader={false}
-      rowClassName={(record: FileNode) => (selectedItems.has(record.path) ? 'folder-content-row-selected' : '')}
+      rowClassName={(record: FileNode) => {
+        if (dragOverFolder === record.path) {
+          return 'folder-content-row folder-content-row-dragover';
+        }
+        if (selectedItems.has(record.path)) {
+          return 'folder-content-row folder-content-row-selected';
+        }
+        return 'folder-content-row';
+      }}
       onRow={(record: FileNode, index?: number) => ({
         onClick: (e: React.MouseEvent<HTMLElement>) => onItemClick(e, record, index ?? 0),
         onDoubleClick: () => record.isDir && onItemDoubleClick(record.path),
@@ -164,15 +172,6 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
         onDragOver: disableDrag ? undefined : (e: React.DragEvent<HTMLElement>) => record.isDir && onFolderDragOver(e, record),
         onDragLeave: disableDrag ? undefined : (e: React.DragEvent<HTMLElement>) => record.isDir && onFolderDragLeave(e),
         onDrop: disableDrag ? undefined : (e: React.DragEvent<HTMLElement>) => record.isDir && onFolderDrop(e, record),
-        style: {
-          backgroundColor: dragOverFolder === record.path
-            ? 'rgba(24, 144, 255, 0.1)'
-            : selectedItems.has(record.path)
-              ? 'rgba(24, 144, 255, 0.08)'
-              : undefined,
-          userSelect: 'none',
-          cursor: 'default',
-        } as React.CSSProperties,
       })}
       locale={{ emptyText: '이 폴더는 비어 있습니다.' }}
     />

--- a/apps/frontend/src/features/browse/hooks/useBoxSelection.ts
+++ b/apps/frontend/src/features/browse/hooks/useBoxSelection.ts
@@ -171,6 +171,9 @@ export function useBoxSelection({
       if (target.closest('[data-selection-exclude="true"]')) {
         return;
       }
+      if (target.closest('button, input, select, textarea, a, [role="button"], .ant-btn, .ant-select, .ant-select-dropdown')) {
+        return;
+      }
 
       // 좌표/스크롤 계산용 컨테이너 체크
       const container = containerRef.current;

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -1786,3 +1786,22 @@
 - **적용 파일**:
   - `apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx`
   - `apps/frontend/src/features/browse/hooks/useContextMenu.ts`
+
+## 2026-02-18: 테이블 선택 UX 및 선택색상 공통화
+- **상황**:
+  - PC 테이블에서 단일 선택 반응이 둔하게 느껴지고, 멀티선택(Shift/Ctrl) 체감이 불안정함.
+  - 그리드/테이블 선택 하이라이트 색상값이 분산되어 미세 불일치가 발생.
+- **결정**:
+  - 테이블 row drag를 비활성화하고, 선택 로직을 앵커 기반으로 정리(Shift=범위 치환, Ctrl/Cmd+Shift=범위 추가).
+  - 컨텍스트 메뉴 선택 인덱스 기준을 `sortedContent`로 통일.
+  - 선택/드래그오버 색상을 CSS 변수(`--browse-selection-*`)로 공통화하고 그리드/테이블이 동일 값 참조.
+- **이유**:
+  - 입력 방식(클릭/터치)은 유지하면서 렌더/상태 갱신 부담과 인덱스 불일치에서 오는 UX 흔들림을 최소화.
+  - 향후 톤 조정을 단일 지점에서 제어 가능.
+- **적용 파일**:
+  - `apps/frontend/src/features/browse/hooks/useFileSelection.ts`
+  - `apps/frontend/src/features/browse/components/FolderContent.tsx`
+  - `apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx`
+  - `apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx`
+  - `apps/frontend/src/features/browse/hooks/useBoxSelection.ts`
+  - `apps/frontend/src/assets/css/global.css`

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -918,3 +918,14 @@
     - `useContextMenu` 빈영역 메뉴 아이템 null/undefined 가드 추가.
     - 검증:
         - `pnpm -C apps/frontend build` 통과.
+
+- **상단 로우 드래그 시작 정책 조정** (2026-02-18):
+    - 기본 브레드크럼/툴바 로우는 박스선택 드래그 시작 허용.
+    - 선택 툴바(선택 N개 표시) 상태에서는 드래그 시작 제외 유지.
+    - 인터랙티브 요소(버튼/입력/셀렉트/링크)에서는 드래그 시작 차단해 버튼 동작 보존.
+
+- **PC 테이블 선택 반응/멀티선택 보정** (2026-02-18):
+    - 테이블 row drag를 비활성화해 클릭 선택 반응 지연 체감 완화.
+    - `useFileSelection`의 Shift 범위선택을 앵커 기반 표준 동작으로 정리(Shift: 범위 치환, Ctrl/Cmd+Shift: 범위 추가).
+    - 컨텍스트 메뉴 선택 기준 배열을 `content`에서 `sortedContent`로 교정해 인덱스/앵커 불일치 보정.
+    - 검증: `pnpm -C apps/frontend exec tsc --noEmit`, `pnpm -C apps/frontend build` 통과.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -139,3 +139,5 @@
 - [x] 박스선택 시작영역 확장 옵션(`startAreaOutsetPx`) 호출부 누락 연결 (`FolderContent`)
 - [x] 박스선택 오버레이를 루트 레이어로 이동해 컨테이너 경계 클리핑 제거
 - [x] 프론트 빌드 타입 에러 정리 (`FolderContentTable`, `useContextMenu`)
+- [x] 기본 브레드크럼/툴바 로우 드래그 허용 + 선택 툴바만 드래그 제외
+- [x] PC 테이블 선택 반응/멀티선택 UX 보정 (row drag off, Shift/Ctrl+Shift 동작 정리, sortedContent 인덱스 정합)


### PR DESCRIPTION
## 요약
- PC 테이블 선택 반응과 멀티선택 동작을 정리했습니다.
- 선택 툴바/상단 드래그 정책을 보강했습니다.
- 그리드/테이블 선택·드래그오버 색상을 공통 변수로 통일했습니다.

## 변경 사항
- `useFileSelection` 선택 로직 개선
  - Shift: 앵커 기반 범위 치환
  - Ctrl/Cmd+Shift: 범위 추가
  - 불필요한 선택 인덱스 state 제거로 렌더 부담 완화
- `FolderContent` 컨텍스트 메뉴 기준 데이터를 `sortedContent`로 통일
- `FolderContentTable` row drag 비활성화 및 선택/드래그오버 스타일을 클래스 기반으로 정리
- `useBoxSelection` 인터랙티브 요소 드래그 시작 제외 가드 추가
- 상단 로우 정책 조정
  - 기본 breadcrumb/툴바 로우 드래그 허용
  - 선택 툴바(`N개 선택됨`) 영역은 드래그/배경 선택해제 제외
- 색상 공통화
  - `global.css`에 `--browse-selection-border-color`, `--browse-selection-bg`, `--browse-dragover-bg` 추가
  - Grid/Table가 동일 변수 참조

## 검증
- `pnpm -C apps/frontend exec tsc --noEmit` PASS
- `pnpm -C apps/frontend build` PASS

## 영향 파일
- `apps/frontend/src/features/browse/hooks/useFileSelection.ts`
- `apps/frontend/src/features/browse/components/FolderContent.tsx`
- `apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx`
- `apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx`
- `apps/frontend/src/features/browse/hooks/useBoxSelection.ts`
- `apps/frontend/src/assets/css/global.css`
- `docs/ai-context/status.md`
- `docs/ai-context/todo.md`
- `docs/ai-context/decision_log.md`