### PR TITLE
fix: 보안 하드닝 1차와 프론트 lint 오류 수정

### DIFF
--- a/apps/backend/go.mod
+++ b/apps/backend/go.mod
@@ -1,6 +1,6 @@
 module taeu.kr/cohesion
 
-go 1.25.4
+go 1.25.7
 
 require (
 	github.com/Masterminds/squirrel v1.5.4

--- a/apps/backend/internal/account/handler.go
+++ b/apps/backend/internal/account/handler.go
@@ -42,7 +42,7 @@ func (h *Handler) handleAccounts(w http.ResponseWriter, r *http.Request) *web.Er
 		}
 		user, err := h.service.CreateUser(r.Context(), &req)
 		if err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to create user", Err: err}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -76,14 +76,14 @@ func (h *Handler) handleAccountByID(w http.ResponseWriter, r *http.Request) *web
 		}
 		user, err := h.service.UpdateUser(r.Context(), id, &req)
 		if err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to update user", Err: err}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(user)
 		return nil
 	case http.MethodDelete:
 		if err := h.service.DeleteUser(r.Context(), id); err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to delete user", Err: err}
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return nil
@@ -97,7 +97,7 @@ func (h *Handler) handlePermissions(w http.ResponseWriter, r *http.Request, user
 	case http.MethodGet:
 		permissions, err := h.service.GetUserPermissions(r.Context(), userID)
 		if err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to get permissions", Err: err}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(permissions)
@@ -113,7 +113,7 @@ func (h *Handler) handlePermissions(w http.ResponseWriter, r *http.Request, user
 			permission.UserID = userID
 		}
 		if err := h.service.ReplaceUserPermissions(r.Context(), userID, req.Permissions); err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to update permissions", Err: err}
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return nil
@@ -142,7 +142,7 @@ func (h *Handler) handleRoles(w http.ResponseWriter, r *http.Request) *web.Error
 		}
 		role, err := h.service.CreateRole(r.Context(), req.Name, req.Description)
 		if err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to create Role", Err: err}
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -172,7 +172,7 @@ func (h *Handler) handleRoleByName(w http.ResponseWriter, r *http.Request) *web.
 			return &web.Error{Code: http.StatusBadRequest, Message: "Invalid request body", Err: err}
 		}
 		if err := h.service.ReplaceRolePermissions(r.Context(), roleName, req.Permissions); err != nil {
-			return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+			return &web.Error{Code: http.StatusBadRequest, Message: "Failed to update Role permissions", Err: err}
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return nil
@@ -182,7 +182,7 @@ func (h *Handler) handleRoleByName(w http.ResponseWriter, r *http.Request) *web.
 		return &web.Error{Code: http.StatusMethodNotAllowed, Message: "Method not allowed"}
 	}
 	if err := h.service.DeleteRole(r.Context(), roleName); err != nil {
-		return &web.Error{Code: http.StatusBadRequest, Message: err.Error(), Err: err}
+		return &web.Error{Code: http.StatusBadRequest, Message: "Failed to delete Role", Err: err}
 	}
 	w.WriteHeader(http.StatusNoContent)
 	return nil

--- a/apps/backend/internal/space/handler/space_handler.go
+++ b/apps/backend/internal/space/handler/space_handler.go
@@ -27,8 +27,8 @@ type SpaceAccessService interface {
 }
 
 type Handler struct {
-	spaceService  *space.Service
-	browseService BrowseService
+	spaceService   *space.Service
+	browseService  BrowseService
 	accountService SpaceAccessService
 }
 
@@ -98,11 +98,11 @@ func (h *Handler) handleGetSpaces(w http.ResponseWriter, r *http.Request) *web.E
 	}
 
 	type listSpaceResponse struct {
-		ID            int64      `json:"id"`
-		SpaceName     string     `json:"space_name"`
-		SpaceDesc     *string    `json:"space_desc,omitempty"`
-		Icon          *string    `json:"icon,omitempty"`
-		SpaceCategory *string    `json:"space_category,omitempty"`
+		ID            int64   `json:"id"`
+		SpaceName     string  `json:"space_name"`
+		SpaceDesc     *string `json:"space_desc,omitempty"`
+		Icon          *string `json:"icon,omitempty"`
+		SpaceCategory *string `json:"space_category,omitempty"`
 	}
 	response := make([]listSpaceResponse, 0, len(filteredSpaces))
 	for _, item := range filteredSpaces {
@@ -140,17 +140,21 @@ func (h *Handler) handleCreateSpace(w http.ResponseWriter, r *http.Request) *web
 	if err != nil {
 		// 에러 타입에 따라 상태 코드 결정
 		statusCode := http.StatusInternalServerError
+		message := "Failed to create Space"
 		if strings.Contains(err.Error(), "validation failed") {
 			statusCode = http.StatusBadRequest
+			message = "Invalid Space request"
 		} else if strings.Contains(err.Error(), "already exists") {
 			statusCode = http.StatusConflict
+			message = "Space already exists"
 		} else if strings.Contains(err.Error(), "does not exist") {
 			statusCode = http.StatusBadRequest
+			message = "Space path does not exist"
 		}
 
 		return &web.Error{
 			Code:    statusCode,
-			Message: err.Error(),
+			Message: message,
 			Err:     err,
 		}
 	}
@@ -226,15 +230,18 @@ func (h *Handler) handleSpaceByID(w http.ResponseWriter, r *http.Request) *web.E
 func (h *Handler) handleDeleteSpace(w http.ResponseWriter, r *http.Request, id int64) *web.Error {
 	if err := h.spaceService.DeleteSpace(r.Context(), id); err != nil {
 		statusCode := http.StatusInternalServerError
+		message := "Failed to delete Space"
 		if strings.Contains(err.Error(), "not found") {
 			statusCode = http.StatusNotFound
+			message = "Space not found"
 		} else if strings.Contains(err.Error(), "invalid") {
 			statusCode = http.StatusBadRequest
+			message = "Invalid Space request"
 		}
 
 		return &web.Error{
 			Code:    statusCode,
-			Message: err.Error(),
+			Message: message,
 			Err:     err,
 		}
 	}

--- a/apps/backend/internal/status/handler.go
+++ b/apps/backend/internal/status/handler.go
@@ -92,6 +92,15 @@ func (h *Handler) checkHTTP() ProtocolStatus {
 }
 
 func (h *Handler) checkWebDAV() ProtocolStatus {
+	if !config.Conf.Server.WebdavEnabled {
+		return ProtocolStatus{
+			Status:  "unavailable",
+			Message: "비활성화",
+			Port:    h.port,
+			Path:    "/dav/",
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 

--- a/apps/backend/internal/webdav/context.go
+++ b/apps/backend/internal/webdav/context.go
@@ -1,0 +1,19 @@
+package webdav
+
+import "context"
+
+type contextKey string
+
+const webDAVUsernameContextKey contextKey = "webdav.username"
+
+func WithUsername(ctx context.Context, username string) context.Context {
+	return context.WithValue(ctx, webDAVUsernameContextKey, username)
+}
+
+func UsernameFromContext(ctx context.Context) (string, bool) {
+	username, ok := ctx.Value(webDAVUsernameContextKey).(string)
+	if !ok || username == "" {
+		return "", false
+	}
+	return username, true
+}

--- a/apps/backend/internal/webdav/handler/webdav_handler.go
+++ b/apps/backend/internal/webdav/handler/webdav_handler.go
@@ -4,35 +4,82 @@ import (
 	"net/http"
 
 	"github.com/rs/zerolog/log"
+	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/platform/web"
 	"taeu.kr/cohesion/internal/webdav"
 )
 
 type Handler struct {
-	webDavService *webdav.Service
+	webDavService  *webdav.Service
+	accountService *account.Service
 }
 
-func NewHandler(webDavService *webdav.Service) *Handler {
+func NewHandler(webDavService *webdav.Service, accountService *account.Service) *Handler {
 	return &Handler{
-		webDavService: webDavService,
+		webDavService:  webDavService,
+		accountService: accountService,
 	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) *web.Error {
+	username, password, ok := r.BasicAuth()
+	if !ok {
+		writeWebDAVUnauthorized(w)
+		return nil
+	}
+	authed, err := h.accountService.Authenticate(r.Context(), username, password)
+	if err != nil {
+		return &web.Error{
+			Code:    http.StatusInternalServerError,
+			Message: "Failed to authenticate WebDAV user",
+			Err:     err,
+		}
+	}
+	if !authed {
+		writeWebDAVUnauthorized(w)
+		return nil
+	}
+
+	ctx := webdav.WithUsername(r.Context(), username)
+
 	// URL 경로에서 space 이름 추출
 	spaceName, _ := webdav.ResolvePath(r.URL.Path)
 
-	// elqjrm
 	log.Debug().Msgf("WebDAV request for space: %s, path: %s", spaceName, r.URL.Path)
 
 	// spaceName이 없으면 루트 핸들러로 위임 (Space 목록 표시)
 	if spaceName == "" {
-		h.webDavService.GetRootHandler().ServeHTTP(w, r)
+		h.webDavService.GetRootHandler().ServeHTTP(w, r.WithContext(ctx))
 		return nil
 	}
 
+	spaceObj, err := h.webDavService.GetSpaceByName(ctx, spaceName)
+	if err != nil {
+		return &web.Error{
+			Code:    http.StatusNotFound,
+			Message: "Space not found",
+			Err:     err,
+		}
+	}
+
+	required := requiredPermissionForMethod(r.Method)
+	allowed, err := h.accountService.CanAccessSpaceByID(ctx, username, spaceObj.ID, required)
+	if err != nil {
+		return &web.Error{
+			Code:    http.StatusInternalServerError,
+			Message: "Failed to evaluate space access",
+			Err:     err,
+		}
+	}
+	if !allowed {
+		return &web.Error{
+			Code:    http.StatusForbidden,
+			Message: "Forbidden",
+		}
+	}
+
 	// 해당 space에 대한 WebDAV 핸들러 가져오기
-	webDavHandler, err := h.webDavService.GetWebDAVHandler(r.Context(), spaceName)
+	webDavHandler, err := h.webDavService.GetWebDAVHandler(ctx, spaceName)
 	if err != nil {
 		return &web.Error{
 			Code:    http.StatusInternalServerError,
@@ -42,6 +89,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) *web.Error {
 	}
 
 	// WebDAV 핸들러로 요청 처리 위임
-	webDavHandler.ServeHTTP(w, r)
+	webDavHandler.ServeHTTP(w, r.WithContext(ctx))
 	return nil
+}
+
+func requiredPermissionForMethod(method string) account.Permission {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, "PROPFIND":
+		return account.PermissionRead
+	default:
+		return account.PermissionWrite
+	}
+}
+
+func writeWebDAVUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="Cohesion WebDAV"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte("Unauthorized"))
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -16,7 +16,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-icons": "^5.5.0",
-    "react-router": "^7.10.0",
+    "react-router": "^7.13.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/frontend/src/api/config.ts
+++ b/apps/frontend/src/api/config.ts
@@ -10,16 +10,8 @@ export interface ServerConfig {
   sftpPort: number;
 }
 
-export interface DatabaseConfig {
-  url: string;
-  user: string;
-  password: string;
-  dbname: string;
-}
-
 export interface Config {
   server: ServerConfig;
-  database: DatabaseConfig;
 }
 
 /**

--- a/apps/frontend/src/theme/themeConfig.ts
+++ b/apps/frontend/src/theme/themeConfig.ts
@@ -117,7 +117,7 @@ export function buildCohesionThemeConfig(isDarkMode: boolean): ThemeConfig {
   const selectionToken = isDarkMode ? darkSelectionToken : lightSelectionToken;
 
   return {
-    cssVar: true,
+    cssVar: {},
     algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
     token: {
       ...sharedToken,

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -6,6 +6,14 @@
 - [ ] 프론트엔드 빌드 및 백엔드 임베딩 동작 확인
 
 ## 기능 구현 / 버그 수정
+- [x] 전체 보안점검 수행 (코드/설정/의존성 점검 및 취약점 우선순위 도출)
+- [x] WebDAV 보안 하드닝 (Basic Auth 강제 + Space 권한 체크 + `webdav_enabled` 플래그 적용)
+- [x] 기본 관리자 초기값 하드닝 (프로덕션 기본 계정/비밀번호 fallback 금지)
+- [x] 프론트 의존성 보안 패치 (`react-router` `^7.13.0`)
+- [x] Go 런타임/툴체인 보안 패치 (`go 1.25.7`, `govulncheck` 재검증)
+- [x] `/api/config` 민감정보 비노출 (`server`만 응답/갱신)
+- [x] 공통 에러 응답 하드닝 (계정/Role/Space API의 `err.Error()` 직접 노출 제거)
+- [x] 프론트 React Hooks lint 하드닝 (`set-state-in-effect`, `refs` 규칙 대응)
 - [x] 다크모드 드래그 선택영역 농도 상향 (테마 클래스 도입 + 다크 오버레이 `40%` 적용)
 - [x] 파일 익스플로러 드래그 선택영역 다크/라이트 적응 (overlay를 `--ant-control-item-bg-active` 기반 `color-mix`로 전환)
 - [x] 파일 익스플로러 드래그 선택영역 반투명 적용 (`--browse-selection-overlay-bg` 도입, 경계선 유지)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0(react@19.2.0)
       react-router:
-        specifier: ^7.10.0
-        version: 7.10.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.13.0
+        version: 7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.7)(react@19.2.0)
@@ -1423,8 +1423,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-router@7.10.0:
-    resolution: {integrity: sha512-FVyCOH4IZ0eDDRycODfUqoN8ZSR2LbTvtx6RPsBgzvJ8xAXlMZNCrOFpu+jb8QbtZnpAd/cEki2pwE848pNGxw==}
+  react-router@7.13.0:
+    resolution: {integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -3039,7 +3039,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-router@7.10.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.1.1
       react: 19.2.0


### PR DESCRIPTION
## 요약
### 문제
- WebDAV 인증/인가 경계 부재로 `/dav` 노출면의 접근 제어가 약했습니다.
- `/api/config` 응답에 민감정보(datasource)가 포함될 수 있었습니다.
- 프로덕션 초기 관리자 계정이 fallback 값으로 생성될 수 있었습니다.
- `react-router` 보안 취약점 및 React Hooks lint 위반으로 안정성이 떨어졌습니다.

### 해결
- WebDAV에 Basic Auth + Space 권한(`read`/`write`) 체크를 적용하고, `webdav_enabled` 설정을 실제 라우트에 반영했습니다.
- 설정 API를 `server` 전용 응답/업데이트로 축소해 민감정보 노출을 제거했습니다.
- 프로덕션에서 관리자 초기 계정 env 필수화 및 비밀번호 최소 길이 검증을 추가했습니다.
- `react-router`를 보안 패치 버전으로 상향하고, `set-state-in-effect`/`refs` lint 위반 코드를 정리했습니다.

### 기대 효과
- 외부 노출 프로토콜(WebDAV) 접근 통제 강화
- 운영 민감정보 노출면 축소
- 기본 계정 오용 리스크 완화
- 프론트 lint/build 안정성 개선

## 관련 이슈
- Closes #95

## 변경 사항
- Backend
  - `apps/backend/main.go`
  - `apps/backend/internal/webdav/context.go`
  - `apps/backend/internal/webdav/handler/webdav_handler.go`
  - `apps/backend/internal/webdav/service.go`
  - `apps/backend/internal/webdav/spacefs.go`
  - `apps/backend/internal/config/handler.go`
  - `apps/backend/internal/account/service.go`
  - `apps/backend/internal/account/handler.go`
  - `apps/backend/internal/space/handler/space_handler.go`
  - `apps/backend/internal/status/handler.go`
  - `apps/backend/go.mod`
- Frontend
  - `apps/frontend/package.json`
  - `apps/frontend/src/api/config.ts`
  - `apps/frontend/src/components/common/BottomSheet.tsx`
  - `apps/frontend/src/features/browse/components/FolderContent.tsx`
  - `apps/frontend/src/theme/themeConfig.ts`
  - `pnpm-lock.yaml`
- Docs
  - `docs/ai-context/status.md`
  - `docs/ai-context/todo.md`
  - `docs/ai-context/decision_log.md`

## 범위
### In Scope
- WebDAV 인증/인가 강화
- 설정 API 민감정보 비노출
- 프로덕션 관리자 fallback 제거
- 의존성/런타임 보안 패치
- Hooks lint 오류 해결

### Out of Scope
- 인증 체계 전면 개편(OAuth/SSO)
- 인프라 레벨 보안 정책(WAF/네트워크 ACL)

## 테스트/검증
- `cd apps/backend && go test ./...` PASS
- `pnpm -C apps/frontend build` PASS
- `pnpm -C apps/frontend lint` PASS (baseline-browser-mapping 업데이트 권고 경고만 존재)
- `pnpm audit --prod` PASS (`No known vulnerabilities found`)
- `cd apps/backend && govulncheck ./...` PASS (`No vulnerabilities found`)

## 리스크 및 대응
- 리스크: WebDAV가 이제 인증 필수이므로 기존 무인증 클라이언트는 재설정 필요
- 모니터링: WebDAV 401/403 비율, Space 접근 거부 로그
- 롤백: PR revert 시 기존 동작으로 복구 가능

## 리뷰 가이드
- 우선 확인 파일
  - `apps/backend/internal/webdav/handler/webdav_handler.go`
  - `apps/backend/internal/webdav/spacefs.go`
  - `apps/backend/internal/config/handler.go`
  - `apps/backend/internal/account/service.go`
  - `apps/frontend/src/features/browse/components/FolderContent.tsx`
- 확인 포인트
  - WebDAV 메서드별 권한 매핑(read/write) 타당성
  - 설정 API 축소가 Settings 동작과 충돌하지 않는지
  - Hooks lint 대응이 동작 타이밍 회귀를 만들지 않는지

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 관련 이슈 링크 확인 (`Closes #95`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [ ] 브레이킹 변경 여부 명시 (WebDAV 인증 필수화는 운영 설정 관점에서 사실상 브레이킹)