### PR TITLE
fix: 초기 admin 부팅 정책 단순화 및 실행문서 정합화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,17 +87,25 @@ go build -o cohesion
 ## 데이터베이스
 
 - **SQLite** (로컬 파일)
-- 위치: `apps/backend/cohesion.db`
+- 위치(기본값):
+  - 개발: `apps/backend/dist/data/cohesion_dev.db`
+  - 프로덕션: `apps/backend/data/cohesion.db`
+- 경로 변경: `apps/backend/config/config.dev.yaml`, `apps/backend/config/config.prod.yaml`의 `database.url` 수정
 - 자동 생성 및 마이그레이션
 
 ## 환경 변수
 
-### 백엔드 (apps/backend/.env)
-```
-ENV=development
-DB_PATH=./cohesion.db
-PORT=3000
-```
+### 백엔드
+- `.env` 자동 로딩 없음 (실행 환경 변수만 사용)
+- 현재 코드에서 `ENV`, `DB_PATH`, `PORT`는 사용하지 않음
+- 사용 중인 환경변수:
+  - `COHESION_JWT_SECRET`
+    - 개발: 미지정 시 기본값 사용
+    - 프로덕션: 필수, 32자 이상
+  - `COHESION_ADMIN_USER` (선택)
+  - `COHESION_ADMIN_PASSWORD` (선택)
+  - `COHESION_ADMIN_NICKNAME` (선택)
+- 초기 admin 기본값(환경변수 미지정 시): `admin` / `admin1234` / `Administrator`
 
 ### 프론트엔드
 - 환경 변수 불필요 (개발 시)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,17 +87,25 @@ go build -o cohesion
 ## 데이터베이스
 
 - **SQLite** (로컬 파일)
-- 위치: `apps/backend/cohesion.db`
+- 위치(기본값):
+  - 개발: `apps/backend/dist/data/cohesion_dev.db`
+  - 프로덕션: `apps/backend/data/cohesion.db`
+- 경로 변경: `apps/backend/config/config.dev.yaml`, `apps/backend/config/config.prod.yaml`의 `database.url` 수정
 - 자동 생성 및 마이그레이션
 
 ## 환경 변수
 
-### 백엔드 (apps/backend/.env)
-```
-ENV=development
-DB_PATH=./cohesion.db
-PORT=3000
-```
+### 백엔드
+- `.env` 자동 로딩 없음 (실행 환경 변수만 사용)
+- 현재 코드에서 `ENV`, `DB_PATH`, `PORT`는 사용하지 않음
+- 사용 중인 환경변수:
+  - `COHESION_JWT_SECRET`
+    - 개발: 미지정 시 기본값 사용
+    - 프로덕션: 필수, 32자 이상
+  - `COHESION_ADMIN_USER` (선택)
+  - `COHESION_ADMIN_PASSWORD` (선택)
+  - `COHESION_ADMIN_NICKNAME` (선택)
+- 초기 admin 기본값(환경변수 미지정 시): `admin` / `admin1234` / `Administrator`
 
 ### 프론트엔드
 - 환경 변수 불필요 (개발 시)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -87,17 +87,25 @@ go build -o cohesion
 ## 데이터베이스
 
 - **SQLite** (로컬 파일)
-- 위치: `apps/backend/cohesion.db`
+- 위치(기본값):
+  - 개발: `apps/backend/dist/data/cohesion_dev.db`
+  - 프로덕션: `apps/backend/data/cohesion.db`
+- 경로 변경: `apps/backend/config/config.dev.yaml`, `apps/backend/config/config.prod.yaml`의 `database.url` 수정
 - 자동 생성 및 마이그레이션
 
 ## 환경 변수
 
-### 백엔드 (apps/backend/.env)
-```
-ENV=development
-DB_PATH=./cohesion.db
-PORT=3000
-```
+### 백엔드
+- `.env` 자동 로딩 없음 (실행 환경 변수만 사용)
+- 현재 코드에서 `ENV`, `DB_PATH`, `PORT`는 사용하지 않음
+- 사용 중인 환경변수:
+  - `COHESION_JWT_SECRET`
+    - 개발: 미지정 시 기본값 사용
+    - 프로덕션: 필수, 32자 이상
+  - `COHESION_ADMIN_USER` (선택)
+  - `COHESION_ADMIN_PASSWORD` (선택)
+  - `COHESION_ADMIN_NICKNAME` (선택)
+- 초기 admin 기본값(환경변수 미지정 시): `admin` / `admin1234` / `Administrator`
 
 ### 프론트엔드
 - 환경 변수 불필요 (개발 시)

--- a/apps/backend/.air.toml
+++ b/apps/backend/.air.toml
@@ -3,42 +3,50 @@ testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
-  # 1. 빌드 명령어
-  cmd = "go build -o ./tmp/main.exe"
+# 1. 빌드 명령어
+cmd = "go build -o ./tmp/main.exe"
 
-  # 2. 빌드된 바이너리 실행 위치
-  entrypoint = "./tmp/main.exe"
+# 2. 빌드된 바이너리 실행 위치
+entrypoint = "./tmp/main.exe"
 
-  # 3. 변경을 감지할 파일 확장자
-  include_ext = ["go", "tpl", "tmpl", "html"]
+# 3. 변경을 감지할 파일 확장자
+include_ext = ["go", "tpl", "tmpl", "html"]
 
-  # 4. 감지에서 제외할 디렉토리 (node_modules 필수 제외)
-  exclude_dir = ["assets", "tmp", "vendor", "testdata", "node_modules", ".turbo", "dist"]
+# 4. 감지에서 제외할 디렉토리 (node_modules 필수 제외)
+exclude_dir = [
+  "assets",
+  "tmp",
+  "vendor",
+  "testdata",
+  "node_modules",
+  ".turbo",
+  "dist",
+]
 
-  # 5. 감지에서 제외할 구체적 파일
-  exclude_file = []
+# 5. 감지에서 제외할 구체적 파일
+exclude_file = []
 
-  # 6. 폴링 주기 (밀리초)
-  delay = 1000
+# 6. 폴링 주기 (밀리초)
+delay = 1000
 
-  # 7. 빌드 에러 발생 시 실행 중단 여부
-  stop_on_error = true
+# 7. 빌드 에러 발생 시 실행 중단 여부
+stop_on_error = true
 
-  # 8. 프로세스 종료 시그널 (Windows 호환성 위해 보통 "windows" 설정)
-  # Mac/Linux는 SIGTERM이 기본값입니다.
-  kill_delay = "500ms"
+# 8. 프로세스 종료 시그널 (Windows 호환성 위해 보통 "windows" 설정)
+# Mac/Linux는 SIGTERM이 기본값입니다.
+kill_delay = "500ms"
 
 [log]
-  # 로그 시간 표시
-  time = true
+# 로그 시간 표시
+time = true
 
 [color]
-  # 터미널 색상 설정
-  main = "magenta"
-  watcher = "cyan"
-  build = "yellow"
-  runner = "green"
+# 터미널 색상 설정
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
 
 [misc]
-  # 종료 시 tmp 디렉토리 삭제 여부
-  clean_on_exit = true
+# 종료 시 tmp 디렉토리 삭제 여부
+clean_on_exit = true

--- a/apps/backend/internal/account/service.go
+++ b/apps/backend/internal/account/service.go
@@ -47,29 +47,17 @@ func (s *Service) EnsureDefaultAdmin(ctx context.Context) error {
 		return nil
 	}
 
-	isProduction := strings.EqualFold(strings.TrimSpace(os.Getenv("ENV")), "production")
-
-	username := os.Getenv("COHESION_ADMIN_USER")
+	username := strings.TrimSpace(os.Getenv("COHESION_ADMIN_USER"))
 	if username == "" {
-		if isProduction {
-			return errors.New("COHESION_ADMIN_USER is required in production")
-		}
 		username = "admin"
 	}
 	password := os.Getenv("COHESION_ADMIN_PASSWORD")
-	if password == "" {
-		if isProduction {
-			return errors.New("COHESION_ADMIN_PASSWORD is required in production")
-		}
+	if strings.TrimSpace(password) == "" {
 		password = "admin1234"
 	}
-	nickname := os.Getenv("COHESION_ADMIN_NICKNAME")
+	nickname := strings.TrimSpace(os.Getenv("COHESION_ADMIN_NICKNAME"))
 	if nickname == "" {
 		nickname = "Administrator"
-	}
-
-	if isProduction && len(password) < 12 {
-		return errors.New("COHESION_ADMIN_PASSWORD must be at least 12 characters in production")
 	}
 
 	if existing, err := s.store.GetUserByUsername(ctx, username); err == nil {

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -78,6 +78,27 @@
 - **이유**:
   - 외부 노출 프로토콜(WebDAV)과 운영 민감정보(API config)는 공격 표면 우선순위가 가장 높아 1차 릴리즈에서 즉시 차단/축소가 필요하다.
 
+### 클릭 실행 UX 기준 초기 관리자 부팅 정책 단순화 (2026-02-19)
+- **문제**:
+  - `EnsureDefaultAdmin`가 `ENV=production`에서 `COHESION_ADMIN_USER`/`COHESION_ADMIN_PASSWORD`를 필수로 강제해, 일반 소비자 대상 더블클릭 실행 환경에서 첫 구동이 실패할 수 있음.
+- **결정**:
+  - 초기 관리자 생성 로직에서 `ENV` 기반 프로덕션 강제 분기를 제거한다.
+  - 환경변수가 비어 있으면 모든 환경에서 `admin/admin1234` + 닉네임 `Administrator`로 fallback 생성한다.
+  - 환경변수(`COHESION_ADMIN_USER`, `COHESION_ADMIN_PASSWORD`, `COHESION_ADMIN_NICKNAME`)가 있으면 기존처럼 override한다.
+- **이유**:
+  - 설치 직후 무설정으로도 즉시 구동 가능한 UX가 제품 요구사항에 더 부합한다.
+
+### 실행 문서 환경변수 안내 정합화 (2026-02-19)
+- **문제**:
+  - 실행 문서(`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`)가 `ENV`, `DB_PATH`, `PORT`를 백엔드 환경변수로 안내하고 있었지만, 실제 코드는 해당 키를 사용하지 않음.
+- **결정**:
+  - 문서의 환경변수 항목을 코드 기준으로 정리:
+    - 사용 중: `COHESION_JWT_SECRET`, `COHESION_ADMIN_USER`, `COHESION_ADMIN_PASSWORD`, `COHESION_ADMIN_NICKNAME`
+    - 미사용: `ENV`, `DB_PATH`, `PORT`
+  - DB 기본 경로도 `config.dev/prod.yaml`의 `database.url` 기준으로 명시.
+- **이유**:
+  - 설치/운영 시 문서-코드 불일치로 인한 오설정을 방지하고, 실행 절차를 단순화하기 위함.
+
 ### 전체 보안점검 기준 및 후속 우선순위 확정 (2026-02-19)
 - **문제**:
   - 최근 기능 추가 이후 인증/권한/파일처리 경계와 의존성 취약점 누적 여부를 한 번에 검증할 필요가 있음.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,16 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **실행 문서 환경변수 섹션 정합화 완료** (2026-02-19):
+    - 문서:
+      - `AGENTS.md`, `GEMINI.md`, `CLAUDE.md`의 환경변수 안내를 실제 코드 동작 기준으로 수정.
+      - `ENV`, `DB_PATH`, `PORT` 사용 안내 제거.
+      - `COHESION_JWT_SECRET`, `COHESION_ADMIN_*` 및 DB 경로(`config.dev/prod.yaml`의 `database.url`) 기준으로 정리.
+- **클릭 실행 UX용 초기 admin 부팅 단순화 완료** (2026-02-19):
+    - 백엔드:
+      - `EnsureDefaultAdmin`에서 `ENV` 기반 production 강제 분기를 제거.
+      - `COHESION_ADMIN_*` 미지정 시 모든 환경에서 `admin/admin1234` + `Administrator` fallback 생성으로 통일.
+      - 환경변수가 주어지면 기존처럼 값 override 유지.
 - **프론트 lint 하드닝 완료 (`react-hooks/set-state-in-effect`, `react-hooks/refs`)** (2026-02-19):
     - 프론트:
       - `BottomSheet`에서 effect 본문의 동기 `setState`를 `requestAnimationFrame` 기반 반영으로 전환.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -9,6 +9,8 @@
 - [x] 전체 보안점검 수행 (코드/설정/의존성 점검 및 취약점 우선순위 도출)
 - [x] WebDAV 보안 하드닝 (Basic Auth 강제 + Space 권한 체크 + `webdav_enabled` 플래그 적용)
 - [x] 기본 관리자 초기값 하드닝 (프로덕션 기본 계정/비밀번호 fallback 금지)
+- [x] 클릭 실행 UX 단순화: 초기 admin 생성의 `ENV` 의존 제거 및 기본 fallback 통합
+- [x] 실행 문서 환경변수 안내 정합화 (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`)
 - [x] 프론트 의존성 보안 패치 (`react-router` `^7.13.0`)
 - [x] Go 런타임/툴체인 보안 패치 (`go 1.25.7`, `govulncheck` 재검증)
 - [x] `/api/config` 민감정보 비노출 (`server`만 응답/갱신)


### PR DESCRIPTION
## 요약

### 문제
- 클릭 실행(무설정) 환경에서 초기 admin 생성이 환경변수 조건에 의해 실패할 수 있었습니다.
- 실행 문서의 환경변수 안내(`ENV`, `DB_PATH`, `PORT`)가 실제 코드 동작과 달랐습니다.
- `apps/backend/.air.toml` 변경이 반영 범위에 포함되어야 했습니다.

### 해결
- `EnsureDefaultAdmin`에서 `ENV` 기반 production 강제 분기를 제거했습니다.
- `COHESION_ADMIN_*` 미지정 시 모든 환경에서 fallback 생성으로 통일했습니다.
- 실행 문서(`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`)를 코드 기준으로 정리했습니다.
- `docs/ai-context`(`decision_log`, `status`, `todo`)를 동기화했습니다.
- `apps/backend/.air.toml` 포맷 정리를 포함했습니다(동작 변경 없음).

### 기대 효과
- 설치 직후 바로 실행 가능한 UX를 확보합니다.
- 문서-코드 불일치로 인한 오설정을 줄입니다.

## 변경 사항
- `apps/backend/internal/account/service.go`
- `apps/backend/.air.toml`
- `AGENTS.md`
- `GEMINI.md`
- `CLAUDE.md`
- `docs/ai-context/decision_log.md`
- `docs/ai-context/status.md`
- `docs/ai-context/todo.md`

## 범위
- In Scope: 초기 admin 생성 정책 단순화, 환경변수 문서 정합화, `.air.toml` 포맷 정리, ai-context 기록 반영
- Out of Scope: JWT secret 정책 변경, 설정 로더 구조 개편

## 테스트/검증
- `cd apps/backend && go test ./...`
- 결과: PASS

## 리스크 및 대응
- 리스크: fallback admin(`admin/admin1234`)은 운영 보안 관점에서 약할 수 있음
- 대응: 운영 배포 시 `COHESION_ADMIN_USER`, `COHESION_ADMIN_PASSWORD` 지정 권장
- 롤백: `apps/backend/internal/account/service.go`, `apps/backend/.air.toml` 리버트

## 리뷰 가이드
- 우선 확인 파일: `apps/backend/internal/account/service.go`
- 추가 확인 파일: `apps/backend/.air.toml`
- 문서 확인 파일: `AGENTS.md`, `GEMINI.md`, `CLAUDE.md`
- 검토 포인트: 초기 admin 생성 조건 단순화 동작, 문서-코드 정합성, `.air.toml`이 포맷 변경만인지