### PR TITLE
feat: 초기 관리자 보안 부팅과 릴리즈 빌드 정비

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: cohesion
+dist: dist/release
+
+before:
+  hooks:
+    - pnpm -C apps/frontend build
+    - node apps/backend/scripts/prepare-web-dist.js
+
+builds:
+  - id: backend
+    dir: ./apps/backend
+    main: .
+    binary: cohesion
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -tags=production
+    ldflags:
+      - -s -w -X main.goEnv=production
+    goos:
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: backend
+    ids:
+      - backend
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+      - src: apps/backend/config/config.prod.yaml
+        dst: config/config.prod.yaml
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Cohesion은 **누구나 쉽게 구축하고 사용할 수 있는** Self-Host 파
 - iOS, Android 웹 브라우저
 - 네이티브 파일 앱 연동 (WebDAV)
 
+## 릴리즈 (GoReleaser)
+
+멀티플랫폼(예: macOS/Windows) 백엔드 릴리즈 빌드는 GoReleaser로 관리합니다.
+
+- 설정 파일: `.goreleaser.yaml`
+- 로컬 설정 검증:
+  - `pnpm release:check`
+- 로컬 스냅샷 릴리즈 아티팩트 생성:
+  - `pnpm release:snapshot`
+
 ## 라이선스
 
 MIT License

--- a/apps/backend/build.js
+++ b/apps/backend/build.js
@@ -1,13 +1,11 @@
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import path from 'path';
 import os from 'os';
 import process from 'process';
-import fsExtra from 'fs-extra';
 
 // 1. 경로 설정
 const currentDir = process.cwd();
 const goCachePath = path.join(currentDir, 'tmp', 'gocache');
-const frontendDistPath = path.join(currentDir, '..', 'frontend', 'dist');
 
 // 2. 환경변수 주입
 const env = {
@@ -21,12 +19,14 @@ console.log(`[Build] OS: ${os.platform()}`);
 console.log(`[Build] GOCACHE: ${goCachePath}`);
 
 // 3. Frontend 빌드 결과물 복사
-if (!fsExtra.existsSync(frontendDistPath)) {
-  console.error(`[Build] Frontend build not found at ${frontendDistPath}. Please build the frontend first.`);
-  process.exit(1);
+const prepareWebDist = spawnSync(process.execPath, ['scripts/prepare-web-dist.js'], {
+  env: env,
+  stdio: 'inherit',
+});
+
+if (prepareWebDist.status !== 0) {
+  process.exit(prepareWebDist.status ?? 1);
 }
-fsExtra.mkdirpSync(path.join(currentDir, 'dist', 'web'));
-fsExtra.copySync(frontendDistPath, path.join(currentDir, 'dist', 'web'));
 
 // 4. Go Build 실행
 // -o dist/main.exe : 결과물을 dist 폴더에 main.exe로 저장

--- a/apps/backend/config/config.dev.yaml
+++ b/apps/backend/config/config.dev.yaml
@@ -8,6 +8,3 @@ server:
   sftp_port: 22
 database:
   url: dist/data/cohesion_dev.db
-  user: test
-  password: test
-  dbname: cohesion

--- a/apps/backend/config/config.prod.yaml
+++ b/apps/backend/config/config.prod.yaml
@@ -8,6 +8,3 @@ server:
   sftp_port: 22
 database:
   url: data/cohesion.db
-  user: test
-  password: test
-  dbname: cohesion

--- a/apps/backend/internal/account/service_bootstrap_test.go
+++ b/apps/backend/internal/account/service_bootstrap_test.go
@@ -1,0 +1,94 @@
+package account_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+	_ "github.com/ncruces/go-sqlite3/embed"
+	"taeu.kr/cohesion/internal/account"
+	"taeu.kr/cohesion/internal/account/store"
+	"taeu.kr/cohesion/internal/platform/database"
+)
+
+func setupBootstrapService(t *testing.T) (*account.Service, *sql.DB) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := database.Migrate(context.Background(), db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	st := store.NewStore(db)
+	return account.NewService(st), db
+}
+
+func TestEnsureDefaultAdmin_DoesNotCreateWeakDefaults(t *testing.T) {
+	t.Setenv("COHESION_ADMIN_USER", "")
+	t.Setenv("COHESION_ADMIN_PASSWORD", "")
+	t.Setenv("COHESION_ADMIN_NICKNAME", "")
+
+	svc, db := setupBootstrapService(t)
+	defer db.Close()
+
+	if err := svc.EnsureDefaultAdmin(context.Background()); err != nil {
+		t.Fatalf("ensure default admin: %v", err)
+	}
+
+	needsBootstrap, err := svc.NeedsBootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("needs bootstrap: %v", err)
+	}
+	if !needsBootstrap {
+		t.Fatal("expected bootstrap to remain required without explicit admin credentials")
+	}
+}
+
+func TestEnsureDefaultAdmin_CreatesAdminWhenEnvProvided(t *testing.T) {
+	t.Setenv("COHESION_ADMIN_USER", "admin-env")
+	t.Setenv("COHESION_ADMIN_PASSWORD", "env-secret-123")
+	t.Setenv("COHESION_ADMIN_NICKNAME", "Env Admin")
+
+	svc, db := setupBootstrapService(t)
+	defer db.Close()
+
+	if err := svc.EnsureDefaultAdmin(context.Background()); err != nil {
+		t.Fatalf("ensure default admin: %v", err)
+	}
+
+	needsBootstrap, err := svc.NeedsBootstrap(context.Background())
+	if err != nil {
+		t.Fatalf("needs bootstrap: %v", err)
+	}
+	if needsBootstrap {
+		t.Fatal("expected bootstrap to complete when env credentials are provided")
+	}
+}
+
+func TestBootstrapInitialAdmin_OnlyAllowsFirstRun(t *testing.T) {
+	svc, db := setupBootstrapService(t)
+	defer db.Close()
+
+	_, err := svc.BootstrapInitialAdmin(context.Background(), &account.CreateUserRequest{
+		Username: "first-admin",
+		Password: "first-admin-password",
+		Nickname: "First Admin",
+	})
+	if err != nil {
+		t.Fatalf("bootstrap initial admin: %v", err)
+	}
+
+	_, err = svc.BootstrapInitialAdmin(context.Background(), &account.CreateUserRequest{
+		Username: "second-admin",
+		Password: "second-admin-password",
+		Nickname: "Second Admin",
+	})
+	if !errors.Is(err, account.ErrInitialSetupCompleted) {
+		t.Fatalf("expected ErrInitialSetupCompleted, got %v", err)
+	}
+}

--- a/apps/backend/internal/auth/auth.go
+++ b/apps/backend/internal/auth/auth.go
@@ -13,6 +13,7 @@ const (
 var (
 	ErrInvalidCredentials = errors.New("invalid username or password")
 	ErrInvalidToken       = errors.New("invalid token")
+	ErrSetupRequired      = errors.New("initial setup required")
 )
 
 type TokenPair struct {

--- a/apps/backend/internal/auth/handler.go
+++ b/apps/backend/internal/auth/handler.go
@@ -48,6 +48,9 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) *web.Error
 		if err == ErrInvalidCredentials {
 			return &web.Error{Code: http.StatusUnauthorized, Message: "Invalid credentials", Err: err}
 		}
+		if err == ErrSetupRequired {
+			return &web.Error{Code: http.StatusPreconditionRequired, Message: "Initial setup required", Err: err}
+		}
 		return &web.Error{Code: http.StatusInternalServerError, Message: "Failed to login", Err: err}
 	}
 

--- a/apps/backend/internal/auth/middleware.go
+++ b/apps/backend/internal/auth/middleware.go
@@ -11,6 +11,8 @@ var publicAPIPaths = map[string]struct{}{
 	"/api/auth/login":   {},
 	"/api/auth/refresh": {},
 	"/api/auth/logout":  {},
+	"/api/setup/status": {},
+	"/api/setup/admin":  {},
 }
 
 func (s *Service) Middleware(next http.Handler) http.Handler {

--- a/apps/backend/internal/auth/service.go
+++ b/apps/backend/internal/auth/service.go
@@ -31,6 +31,14 @@ func NewService(accountService *account.Service, config Config) *Service {
 }
 
 func (s *Service) Login(ctx context.Context, username, password string) (*TokenPair, *account.User, error) {
+	needsSetup, err := s.accountService.NeedsBootstrap(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if needsSetup {
+		return nil, nil, ErrSetupRequired
+	}
+
 	authed, err := s.accountService.Authenticate(ctx, username, password)
 	if err != nil {
 		return nil, nil, err

--- a/apps/backend/internal/config/config_model.go
+++ b/apps/backend/internal/config/config_model.go
@@ -18,8 +18,5 @@ type Server struct {
 }
 
 type Datasource struct {
-	URL      string `mapstructure:"url" json:"url" yaml:"url"`
-	User     string `mapstructure:"user" json:"user" yaml:"user"`
-	Password string `mapstructure:"password" json:"password" yaml:"password"`
-	DBName   string `mapstructure:"dbname" json:"dbname" yaml:"dbname"`
+	URL string `mapstructure:"url" json:"url" yaml:"url"`
 }

--- a/apps/backend/internal/platform/database/db.go
+++ b/apps/backend/internal/platform/database/db.go
@@ -3,9 +3,12 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
@@ -13,13 +16,21 @@ import (
 	"taeu.kr/cohesion/internal/config"
 )
 
-func NewDB() (*sql.DB, error) {
-	var dbPath = config.Conf.Datasource.URL
+const (
+	dbDirPermission  = 0700
+	dbFilePermission = 0600
+)
 
-	// Ensure the directory for the database file exists
-	if dir := filepath.Dir(dbPath); dir != "." {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return nil, fmt.Errorf("failed to create data directory: %w", err)
+func NewDB() (*sql.DB, error) {
+	dbPath := resolveSQLiteDBPath(strings.TrimSpace(config.Conf.Datasource.URL))
+	if dbPath == "" {
+		return nil, errors.New("database url is required")
+	}
+
+	if !isInMemorySQLiteDB(dbPath) {
+		// Ensure the directory and database file exist with owner-only permissions.
+		if err := ensureDatabasePath(dbPath); err != nil {
+			return nil, err
 		}
 	}
 
@@ -43,5 +54,66 @@ func NewDB() (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
+	if !isInMemorySQLiteDB(dbPath) {
+		if err := enforceOwnerOnlyPermissions(dbPath, dbFilePermission); err != nil {
+			return nil, fmt.Errorf("failed to enforce database file permission: %w", err)
+		}
+	}
+
 	return db, nil
+}
+
+func ensureDatabasePath(dbPath string) error {
+	if dir := filepath.Dir(dbPath); dir != "." {
+		if err := os.MkdirAll(dir, dbDirPermission); err != nil {
+			return fmt.Errorf("failed to create data directory: %w", err)
+		}
+		if err := enforceOwnerOnlyPermissions(dir, dbDirPermission); err != nil {
+			return fmt.Errorf("failed to enforce data directory permission: %w", err)
+		}
+	}
+
+	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
+		file, createErr := os.OpenFile(dbPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, dbFilePermission)
+		if createErr != nil && !errors.Is(createErr, os.ErrExist) {
+			return fmt.Errorf("failed to create database file: %w", createErr)
+		}
+		if createErr == nil {
+			_ = file.Close()
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to inspect database file: %w", err)
+	}
+
+	if err := enforceOwnerOnlyPermissions(dbPath, dbFilePermission); err != nil {
+		return fmt.Errorf("failed to enforce database file permission: %w", err)
+	}
+
+	return nil
+}
+
+func enforceOwnerOnlyPermissions(path string, perm os.FileMode) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return os.Chmod(path, perm)
+}
+
+func isInMemorySQLiteDB(dbPath string) bool {
+	return dbPath == ":memory:" || strings.HasPrefix(dbPath, "file::memory:")
+}
+
+func resolveSQLiteDBPath(dbPath string) string {
+	if dbPath == "" || isInMemorySQLiteDB(dbPath) {
+		return dbPath
+	}
+	if filepath.IsAbs(dbPath) || strings.HasPrefix(dbPath, "file:") {
+		return dbPath
+	}
+
+	if configDir := strings.TrimSpace(config.ConfigDir()); configDir != "" {
+		return filepath.Clean(filepath.Join(configDir, dbPath))
+	}
+
+	return dbPath
 }

--- a/apps/backend/scripts/prepare-web-dist.js
+++ b/apps/backend/scripts/prepare-web-dist.js
@@ -1,0 +1,18 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fsExtra from 'fs-extra';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const backendDir = path.resolve(scriptDir, '..');
+const frontendDistPath = path.resolve(backendDir, '..', 'frontend', 'dist');
+const backendWebDistPath = path.resolve(backendDir, 'dist', 'web');
+
+if (!fsExtra.existsSync(frontendDistPath)) {
+  console.error(`[Build] Frontend build not found at ${frontendDistPath}. Please build the frontend first.`);
+  process.exit(1);
+}
+
+fsExtra.emptyDirSync(backendWebDistPath);
+fsExtra.copySync(frontendDistPath, backendWebDistPath);
+
+console.log(`[Build] Frontend assets copied to ${backendWebDistPath}`);

--- a/apps/frontend/src/api/setup.ts
+++ b/apps/frontend/src/api/setup.ts
@@ -1,0 +1,57 @@
+import { apiFetch } from './client';
+
+export interface SetupStatusResponse {
+  requiresSetup: boolean;
+}
+
+export interface BootstrapAdminRequest {
+  username: string;
+  password: string;
+  nickname?: string;
+}
+
+function parseErrorMessage(data: unknown, fallback: string): string {
+  if (!data || typeof data !== 'object') {
+    return fallback;
+  }
+  const maybeError = (data as { error?: unknown }).error;
+  if (typeof maybeError === 'string' && maybeError.trim().length > 0) {
+    return maybeError;
+  }
+  const maybeMessage = (data as { message?: unknown }).message;
+  if (typeof maybeMessage === 'string' && maybeMessage.trim().length > 0) {
+    return maybeMessage;
+  }
+  return fallback;
+}
+
+async function throwResponseError(response: Response, fallback: string): Promise<never> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  throw new Error(parseErrorMessage(body, fallback));
+}
+
+export async function getSetupStatus(): Promise<SetupStatusResponse> {
+  const response = await apiFetch('/api/setup/status', undefined, { skipAuthHandling: true });
+  if (!response.ok) {
+    await throwResponseError(response, '초기 설정 상태 조회에 실패했습니다');
+  }
+  return response.json();
+}
+
+export async function bootstrapAdmin(payload: BootstrapAdminRequest): Promise<void> {
+  const response = await apiFetch('/api/setup/admin', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  }, { skipAuthHandling: true });
+  if (!response.ok) {
+    await throwResponseError(response, '관리자 초기 설정에 실패했습니다');
+  }
+}

--- a/apps/frontend/src/pages/Login/index.tsx
+++ b/apps/frontend/src/pages/Login/index.tsx
@@ -1,8 +1,9 @@
-import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
 import { App, Button, Card, Input, Space, Typography } from 'antd';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Navigate, useLocation, useNavigate } from 'react-router';
 import { useAuth } from '@/features/auth/useAuth';
+import { bootstrapAdmin, getSetupStatus } from '@/api/setup';
 import '@/assets/css/login.css';
 
 const { Title, Text } = Typography;
@@ -12,14 +13,41 @@ const Login = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, isLoading, login } = useAuth();
+  const [setupChecked, setSetupChecked] = useState(false);
+  const [requiresSetup, setRequiresSetup] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [setupNickname, setSetupNickname] = useState('');
+  const [setupPasswordConfirm, setSetupPasswordConfirm] = useState('');
 
   if (!isLoading && user) {
     const state = location.state as { from?: string } | null;
     const to = state?.from ?? '/';
     return <Navigate to={to} replace />;
+  }
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const status = await getSetupStatus();
+        setRequiresSetup(status.requiresSetup);
+      } catch {
+        message.error('초기 설정 상태를 확인하지 못했습니다');
+      } finally {
+        setSetupChecked(true);
+      }
+    })();
+  }, [message]);
+
+  if (isLoading || !setupChecked) {
+    return (
+      <div className="login-page">
+        <Card className="login-card">
+          <Text type="secondary">로딩 중...</Text>
+        </Card>
+      </div>
+    );
   }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -46,36 +74,109 @@ const Login = () => {
     }
   };
 
+  const handleSetupSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (username.trim().length < 3) {
+      message.error('아이디는 3자 이상이어야 합니다');
+      return;
+    }
+    if (setupPasswordConfirm.trim().length < 8) {
+      message.error('비밀번호는 8자 이상이어야 합니다');
+      return;
+    }
+    if (password !== setupPasswordConfirm) {
+      message.error('비밀번호 확인이 일치하지 않습니다');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await bootstrapAdmin({
+        username: username.trim(),
+        password: password,
+        nickname: setupNickname.trim(),
+      });
+      message.success('초기 관리자 계정이 생성되었습니다');
+      setRequiresSetup(false);
+
+      await login(username.trim(), password);
+      navigate('/', { replace: true });
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '초기 설정에 실패했습니다');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <div className="login-page">
       <Card className="login-card">
         <Space orientation="vertical" size="middle" className="login-stack">
           <div>
             <Title level={3} className="login-title">Cohesion</Title>
-            <Text type="secondary">계정으로 로그인하세요</Text>
+            <Text type="secondary">
+              {requiresSetup ? '초기 관리자 계정을 생성하세요' : '계정으로 로그인하세요'}
+            </Text>
           </div>
 
-          <form onSubmit={handleSubmit} className="login-form">
-            <Space orientation="vertical" size="small" className="login-stack">
-              <Input
-                autoComplete="username"
-                prefix={<UserOutlined />}
-                placeholder="아이디"
-                value={username}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => setUsername(event.target.value)}
-              />
-              <Input.Password
-                autoComplete="current-password"
-                prefix={<LockOutlined />}
-                placeholder="비밀번호"
-                value={password}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => setPassword(event.target.value)}
-              />
-              <Button type="primary" htmlType="submit" loading={submitting} block>
-                로그인
-              </Button>
-            </Space>
-          </form>
+          {requiresSetup ? (
+            <form onSubmit={handleSetupSubmit} className="login-form">
+              <Space orientation="vertical" size="small" className="login-stack">
+                <Input
+                  autoComplete="username"
+                  prefix={<UserOutlined />}
+                  placeholder="관리자 아이디"
+                  value={username}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setUsername(event.target.value)}
+                />
+                <Input
+                  placeholder="닉네임 (선택)"
+                  value={setupNickname}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setSetupNickname(event.target.value)}
+                />
+                <Input.Password
+                  autoComplete="new-password"
+                  prefix={<LockOutlined />}
+                  placeholder="비밀번호 (8자 이상)"
+                  value={password}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setPassword(event.target.value)}
+                />
+                <Input.Password
+                  autoComplete="new-password"
+                  prefix={<LockOutlined />}
+                  placeholder="비밀번호 확인"
+                  value={setupPasswordConfirm}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setSetupPasswordConfirm(event.target.value)}
+                />
+                <Button type="primary" htmlType="submit" loading={submitting} block>
+                  초기 설정 완료
+                </Button>
+              </Space>
+            </form>
+          ) : (
+            <form onSubmit={handleSubmit} className="login-form">
+              <Space orientation="vertical" size="small" className="login-stack">
+                <Input
+                  autoComplete="username"
+                  prefix={<UserOutlined />}
+                  placeholder="아이디"
+                  value={username}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setUsername(event.target.value)}
+                />
+                <Input.Password
+                  autoComplete="current-password"
+                  prefix={<LockOutlined />}
+                  placeholder="비밀번호"
+                  value={password}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => setPassword(event.target.value)}
+                />
+                <Button type="primary" htmlType="submit" loading={submitting} block>
+                  로그인
+                </Button>
+              </Space>
+            </form>
+          )}
         </Space>
       </Card>
     </div>

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -9,8 +9,12 @@
 - [x] 전체 보안점검 수행 (코드/설정/의존성 점검 및 취약점 우선순위 도출)
 - [x] WebDAV 보안 하드닝 (Basic Auth 강제 + Space 권한 체크 + `webdav_enabled` 플래그 적용)
 - [x] 기본 관리자 초기값 하드닝 (프로덕션 기본 계정/비밀번호 fallback 금지)
-- [x] 클릭 실행 UX 단순화: 초기 admin 생성의 `ENV` 의존 제거 및 기본 fallback 통합
+- [x] 초기 관리자 보안 부팅 전환 (기본 fallback 제거 + 최초 실행 setup API/화면 도입)
+- [x] JWT/SQLite 로컬 비밀값 하드닝 (JWT 랜덤 시크릿 파일 생성, DB 파일 권한 제한)
 - [x] 실행 문서 환경변수 안내 정합화 (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`)
+- [x] GoReleaser 도입 (멀티플랫폼 릴리즈 설정)
+- [x] 설정 파일 탐색 기준 보강 (실행파일 위치 우선 + `cwd/config` fallback)
+- [x] 설정 파일 미존재 시 기본 config 자동 생성 (실행파일 기준)
 - [x] 프론트 의존성 보안 패치 (`react-router` `^7.13.0`)
 - [x] Go 런타임/툴체인 보안 패치 (`go 1.25.7`, `govulncheck` 재검증)
 - [x] `/api/config` 민감정보 비노출 (`server`만 응답/갱신)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
+    "release:check": "go run github.com/goreleaser/goreleaser/v2@v2.13.3 check --config .goreleaser.yaml",
+    "release:snapshot": "go run github.com/goreleaser/goreleaser/v2@v2.13.3 release --snapshot --clean --config .goreleaser.yaml",
     "lint": "turbo lint",
     "clean": "rimraf --glob **/dist **/build **/.turbo **/tmp",
     "clean-all": "rimraf --glob **/dist **/build **/.turbo **/tmp node_modules **/node_modules"


### PR DESCRIPTION
## 요약
### 문제
- 기본 관리자 fallback(`admin/admin1234`)과 정적 JWT 시크릿 fallback은 배포 환경 보안 리스크가 있었다.
- 실행 위치에 따라 `config.prod` 탐색 실패가 발생했고, 릴리즈 산출물 실행 경로에서 초기 구동 실패가 재현되었다.
- 멀티플랫폼 배포 빌드 루틴이 표준화되어 있지 않아 운영 빌드 재현성이 낮았다.

### 해결
- 초기 관리자 기본 자격증명 fallback 제거 + 최초 실행 setup 플로우 도입.
- JWT 시크릿 자동 생성/파일 저장, SQLite 파일 권한 하드닝 적용.
- config 탐색을 실행파일 기준으로 전환하고, config 미존재 시 기본 파일 자동 생성.
- GoReleaser 도입으로 macOS/Windows 릴리즈 빌드/아카이브/체크섬 생성 표준화.

### 기대 효과
- 기본 자격증명/고정 시크릿 의존 제거로 초기 보안 수준 향상.
- 더블클릭/직접 실행 환경에서 설정 파일 미존재로 인한 부팅 실패 제거.
- 배포 아티팩트 생성 절차 단순화 및 재현성 향상.

## 관련 이슈
- Related #95

## 변경 사항
- Backend
  - 최초 실행 setup API 추가: `GET /api/setup/status`, `POST /api/setup/admin`
  - 로그인 시 setup 미완료 상태면 `428 Precondition Required` 반환
  - 기본 admin fallback 제거, 환경변수 기반 1회 bootstrap만 허용
  - JWT 시크릿 자동 생성/저장(`COHESION_JWT_SECRET_FILE` 지원)
  - config 탐색 경로를 실행파일 우선으로 변경 + 미존재 시 기본 config 자동 생성
  - SQLite DB 경로를 config 파일 기준으로 해석 + 파일/디렉토리 권한 제한(Unix)
- Frontend
  - 로그인 페이지에 최초 실행 관리자 생성 UI/플로우 추가
  - setup API 클라이언트 추가
- Build/Release
  - `.goreleaser.yaml` 추가
  - `apps/backend/scripts/prepare-web-dist.js` 추가
  - `apps/backend/build.js`에서 웹 에셋 준비 스크립트 재사용
  - 루트 스크립트 `release:check`, `release:snapshot` 추가
- Docs
  - README/ai-context 문서 동기화

## 범위
### In Scope
- 초기 관리자 부팅 보안 정책 전환
- JWT/SQLite 로컬 비밀값/파일 권한 하드닝
- 설정 파일 탐색/자동 생성 안정화
- GoReleaser 기반 릴리즈 빌드 도입

### Out of Scope
- OAuth/SSO 등 인증 체계 재설계
- 인프라 레벨 비밀관리(KMS/HSM) 도입

## 테스트/검증
- `cd apps/backend && go test ./...` PASS
- `pnpm -C apps/frontend build` PASS
- `pnpm build` PASS
- `pnpm release:snapshot` PASS
- 수동 검증
  - `./dist/release/backend_darwin_arm64_v8.0/cohesion` 실행 시
    - config 미존재 상태에서 `config.prod.yaml` 자동 생성 확인
    - 서버 정상 기동 확인

## 리스크 및 대응
- 리스크: 최초 실행 시 자동 생성된 기본 config 값(포트/DB 경로)이 환경 기대와 다를 수 있음.
- 대응: 생성된 `config/config.prod.yaml`를 명시적으로 편집 가능, `/api/config`로 서버 섹션 갱신 가능.
- 롤백: 본 PR revert 후 기존 환경변수/수동 config 배포 방식으로 복귀.

## 리뷰 가이드
- `apps/backend/internal/account/service.go`
- `apps/backend/internal/auth/service.go`
- `apps/backend/internal/config/handler.go`
- `apps/backend/internal/platform/database/db.go`
- `apps/backend/main.go`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 관련 이슈 링크 확인
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트 반영
- [x] 브레이킹 변경 여부 확인 (없음)