### PR TITLE
fix: 버튼 box-shadow 전역 제거

### DIFF
--- a/apps/frontend/src/assets/css/global.css
+++ b/apps/frontend/src/assets/css/global.css
@@ -227,6 +227,20 @@ html, body {
   background: transparent !important;
 }
 
+.ant-btn,
+.ant-btn:hover,
+.ant-btn:active,
+.ant-btn:focus,
+.ant-btn:focus-visible,
+.ant-btn.ant-btn-default,
+.ant-btn.ant-btn-default:hover,
+.ant-btn.ant-btn-default:active,
+.ant-btn.ant-btn-primary,
+.ant-btn.ant-btn-primary:hover,
+.ant-btn.ant-btn-primary:active {
+  box-shadow: none !important;
+}
+
 .bottom-sheet-root {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## 요약
### 문제
- 일부 `antd` 버튼이 상태별 기본 그림자(`box-shadow`)를 가져서 하단에 겹쳐 보이는 UI 인상이 발생.

### 해결
- 전역 CSS에서 버튼 상태별 `box-shadow`를 `none !important`로 강제.
- 대상: 기본/hover/active/focus/default/primary 버튼 상태.

### 기대 효과
- 메인 툴바/설정 화면 등 버튼 렌더링 일관성 확보.
- 버튼 하단 그림자처럼 보이던 시각적 노이즈 제거.

## 관련 이슈
- Closes #99

## 변경 사항
- `apps/frontend/src/assets/css/global.css`
  - `.ant-btn` 및 상태 셀렉터에 `box-shadow: none !important` 추가.

## 범위
### In Scope
- 버튼 그림자 제거

### Out of Scope
- 카드/모달/시트 등 버튼 외 컴포넌트 그림자 정책 변경

## 테스트/검증
- `pnpm -C apps/frontend build` PASS

## 리스크 및 대응
- 리스크: 버튼 입체감이 줄어들 수 있음.
- 대응: 필요 시 특정 버튼 클래스에만 그림자 재도입 가능.
- 롤백: 해당 CSS 블록 revert.

## 리뷰 가이드
- `apps/frontend/src/assets/css/global.css:230`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] 빌드/테스트 통과
- [x] 문서 업데이트 불필요 확인