### PR TITLE
refactor: http_enabled 설정 제거 및 서버 설정 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ apps/server/data/*.db*
 .env.test.local
 .env.production.local
 
+# Runtime secrets
+**/config/secrets/
+
 # Logs
 logs/
 *.log

--- a/apps/backend/config/config.dev.yaml
+++ b/apps/backend/config/config.dev.yaml
@@ -1,6 +1,5 @@
 server:
     port: "3000"
-    http_enabled: true
     webdav_enabled: true
     sftp_enabled: true
     sftp_port: 2222

--- a/apps/backend/config/config.prod.yaml
+++ b/apps/backend/config/config.prod.yaml
@@ -1,6 +1,5 @@
 server:
   port: "3000"
-  http_enabled: true
   webdav_enabled: true
   sftp_enabled: false
   sftp_port: 2222

--- a/apps/backend/internal/config/config_model.go
+++ b/apps/backend/internal/config/config_model.go
@@ -9,7 +9,6 @@ type Config struct {
 
 type Server struct {
 	Port          string `mapstructure:"port" json:"port" yaml:"port"`
-	HttpEnabled   bool   `mapstructure:"http_enabled" json:"httpEnabled" yaml:"http_enabled"`
 	WebdavEnabled bool   `mapstructure:"webdav_enabled" json:"webdavEnabled" yaml:"webdav_enabled"`
 	SftpEnabled   bool   `mapstructure:"sftp_enabled" json:"sftpEnabled" yaml:"sftp_enabled"`
 	SftpPort      int    `mapstructure:"sftp_port" json:"sftpPort" yaml:"sftp_port"`

--- a/apps/backend/internal/config/handler.go
+++ b/apps/backend/internal/config/handler.go
@@ -95,7 +95,6 @@ func defaultConfigForEnv(goEnv string) Config {
 	config := Config{
 		Server: Server{
 			Port:          "3000",
-			HttpEnabled:   true,
 			WebdavEnabled: true,
 			SftpEnabled:   false,
 			SftpPort:      2222,

--- a/apps/frontend/src/api/config.ts
+++ b/apps/frontend/src/api/config.ts
@@ -2,7 +2,6 @@ import { apiFetch } from './client';
 
 export interface ServerConfig {
   port: string;
-  httpEnabled: boolean;
   webdavEnabled: boolean;
   sftpEnabled: boolean;
   sftpPort: number;

--- a/apps/frontend/src/pages/Settings/sections/ServerSettings.tsx
+++ b/apps/frontend/src/pages/Settings/sections/ServerSettings.tsx
@@ -199,36 +199,21 @@ const ServerSettings = () => {
         </Button>
       </Space>
 
-      <Card title="HTTP 서버" size="small">
+      <Card title="WEB 서버" size="small">
         <Space vertical size="small" className="settings-stack-full">
           <SettingRow
-            left={<Text strong>활성화</Text>}
+            left={<Text strong>포트</Text>}
             right={(
-              <Switch
-                checked={server.httpEnabled}
-                onChange={(checked: boolean) => updateServerConfig('httpEnabled', checked)}
+              <InputNumber
+                size="small"
+                min={1}
+                max={65535}
+                value={parseInt(server.port)}
+                onChange={(value: number | null) => value && updateServerConfig('port', value.toString())}
+                className="settings-port-input"
               />
             )}
           />
-
-          {server.httpEnabled && (
-            <>
-              <Divider className="settings-divider-compact" />
-              <SettingRow
-                left={<Text strong>포트</Text>}
-                right={(
-                  <InputNumber
-                    size="small"
-                    min={1}
-                    max={65535}
-                    value={parseInt(server.port)}
-                    onChange={(value: number | null) => value && updateServerConfig('port', value.toString())}
-                    className="settings-port-input"
-                  />
-                )}
-              />
-            </>
-          )}
         </Space>
       </Card>
 
@@ -240,12 +225,11 @@ const ServerSettings = () => {
               <Switch
                 checked={server.webdavEnabled}
                 onChange={(checked: boolean) => updateServerConfig('webdavEnabled', checked)}
-                disabled={!server.httpEnabled}
               />
             )}
           />
 
-          {server.webdavEnabled && server.httpEnabled && (
+          {server.webdavEnabled && (
             <>
               <Divider className="settings-divider-compact" />
               <SettingRow

--- a/apps/frontend/src/stores/settingsStore.ts
+++ b/apps/frontend/src/stores/settingsStore.ts
@@ -7,8 +7,6 @@ export type SortOrder = 'ascend' | 'descend';
 export type Language = 'ko' | 'en';
 
 interface ServerSettings {
-  // HTTP Server
-  httpEnabled: boolean;
   httpPort: number;
 
   // WebDAV
@@ -44,7 +42,6 @@ interface SettingsStore extends UISettings, ServerSettings {
   setLanguage: (lang: Language) => void;
 
   // Server Actions
-  setHttpEnabled: (enabled: boolean) => void;
   setHttpPort: (port: number) => void;
   setWebdavEnabled: (enabled: boolean) => void;
   setWebdavPort: (port: number) => void;
@@ -55,7 +52,6 @@ interface SettingsStore extends UISettings, ServerSettings {
 }
 
 const defaultServerSettings: ServerSettings = {
-  httpEnabled: true,
   httpPort: 3000,
   webdavEnabled: true,
   webdavPort: 3000, // WebDAV uses same port as HTTP (path: /dav/)
@@ -97,7 +93,6 @@ export const useSettingsStore = create<SettingsStore>()(
       setLanguage: (lang) => set({ language: lang }),
 
       // Server actions
-      setHttpEnabled: (enabled) => set({ httpEnabled: enabled }),
       setHttpPort: (port) => set({ httpPort: port }),
       setWebdavEnabled: (enabled) => set({ webdavEnabled: enabled }),
       setWebdavPort: (port) => set({ webdavPort: port }),

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,24 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### `http_enabled` 설정 필드 제거 (2026-02-20)
+- **문제**:
+  - HTTP 서버는 현재 아키텍처에서 필수 경로(API/SPA/WebDAV 베이스)인데, `http_enabled` 토글은 실제 런타임 제어에 사용되지 않아 설정 의미가 불명확함.
+- **결정**:
+  - 백엔드 설정 모델/기본 config YAML/API 응답 모델에서 `http_enabled`를 제거한다.
+  - 프론트 서버 설정 화면에서도 HTTP 활성화 토글을 제거하고 포트 설정만 유지한다.
+  - WebDAV UI의 `httpEnabled` 의존 조건을 제거한다.
+- **이유**:
+  - 실제 동작과 불일치한 데드 설정을 제거해 운영 혼선을 줄이고, 서버 설정을 `port + webdav + sftp`의 유효 제어 항목으로 단순화하기 위함.
+
+### 모노레포 `config/secrets` Git 제외 범위 확장 (2026-02-20)
+- **문제**:
+  - 백엔드 하위(`apps/backend/config/secrets`)는 개별 `.gitignore`로 제외되지만, 모노레포 루트 기준의 `config/secrets` 생성 경로는 전역 제외 규칙이 없어 실수로 추적될 여지가 있음.
+- **결정**:
+  - 루트 `.gitignore`에 `**/config/secrets/` 패턴을 추가해 모든 워크스페이스의 `config/secrets`를 일괄 제외한다.
+- **이유**:
+  - SFTP host key/JWT secret 같은 런타임 생성 비밀키 파일의 Git 유출 위험을 경로 편차와 무관하게 차단하기 위함.
+
 ### Status 팝오버 섹션 순서 재구성 (2026-02-20)
 - **문제**:
   - 접속 URL(로컬/LAN)과 프로토콜 상태가 한 흐름으로 섞여 보여 정보 그룹이 직관적이지 않음.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,27 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **`http_enabled` 설정 필드 제거 완료** (2026-02-20):
+    - 백엔드:
+      - 설정 모델 `server.http_enabled` 제거.
+      - 기본 설정 생성값(`defaultConfigForEnv`)에서 `http_enabled` 제거.
+      - 기본 설정 파일(`config.dev.yaml`, `config.prod.yaml`)에서 `http_enabled` 키 제거.
+    - 프론트:
+      - 설정 API 타입(`ServerConfig`)에서 `httpEnabled` 제거.
+      - 서버 설정 UI에서 HTTP 활성화 토글 제거, WEB 포트 설정만 유지.
+      - WebDAV 섹션의 `httpEnabled` 의존 조건/비활성화 로직 제거.
+      - 설정 스토어에서 `httpEnabled`, `setHttpEnabled` 제거.
+    - 검증:
+      - `cd apps/backend && go test ./...` 통과
+      - `pnpm -C apps/frontend lint` 통과
+      - `pnpm -C apps/frontend exec tsc --noEmit` 통과
+      - `pnpm -C apps/frontend build` 통과
+- **외부 접근 프로토콜 도입 우선순위 분석 및 시크릿 ignore 정리 완료** (2026-02-20):
+    - 분석:
+      - 현재 동작 프로토콜은 `WEB + WebDAV + SFTP`이며, 외부 노출 기준 우선순위를 `HTTPS 종단(필수) -> SFTP 운영 -> WebDAV HTTPS 한정`으로 정리.
+      - `SMB/NFS`는 현재 구현 부재 상태로 확인되어 즉시 도입보다 2차 로드맵(특히 LAN 전용)으로 분류.
+    - 설정/보안:
+      - 루트 `.gitignore`에 `**/config/secrets/`를 추가해 모노레포 전역 `config/secrets` 하위 런타임 시크릿이 Git 추적되지 않도록 보강.
 - **Status 팝오버 섹션 재배치 완료** (2026-02-20):
     - 프론트:
       - `Status` 팝오버를 `Hosts`(상단) → `Protocols`(하단) 순서로 재배치.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -6,6 +6,8 @@
 - [ ] 프론트엔드 빌드 및 백엔드 임베딩 동작 확인
 
 ## 기능 구현 / 버그 수정
+- [x] `http_enabled/httpEnabled` 설정 필드 제거 (백엔드 설정 모델/기본 YAML + 프론트 설정 타입/UI/스토어 정리)
+- [x] 모노레포 전역 `config/secrets` Git ignore 보강 (`.gitignore`에 `**/config/secrets/` 추가)
 - [x] 전체 보안점검 수행 (코드/설정/의존성 점검 및 취약점 우선순위 도출)
 - [x] WebDAV 보안 하드닝 (Basic Auth 강제 + Space 권한 체크 + `webdav_enabled` 플래그 적용)
 - [x] 기본 관리자 초기값 하드닝 (프로덕션 기본 계정/비밀번호 fallback 금지)


### PR DESCRIPTION
## 요약
### 문제
- `server.http_enabled` 설정은 실제 런타임 기동 제어에 사용되지 않아 설정 의미와 실제 동작이 불일치했습니다.
- UI에도 HTTP 활성화 토글이 노출되어 운영자가 비활성화를 기대할 수 있는 혼선이 있었습니다.

### 해결
- 백엔드/프론트 전반에서 `http_enabled/httpEnabled` 필드를 제거했습니다.
- 서버 설정 UI를 `WEB 포트 + WebDAV + SFTP` 중심으로 단순화했습니다.
- 모노레포 전역 `config/secrets` 경로를 루트 `.gitignore`에서 제외하도록 보강했습니다.

### 기대 효과
- 데드 설정 제거로 운영 혼선 감소
- 실제 제어 가능한 설정만 남겨 설정 일관성 향상
- 런타임 시크릿 Git 유출 위험 완화

## 관련 이슈
- Related: 없음

## 변경 사항
- 백엔드
  - `apps/backend/internal/config/config_model.go`: `HttpEnabled` 필드 제거
  - `apps/backend/internal/config/handler.go`: 기본 config 생성값에서 `http_enabled` 제거
  - `apps/backend/config/config.dev.yaml`, `apps/backend/config/config.prod.yaml`: `http_enabled` 키 제거
- 프론트
  - `apps/frontend/src/api/config.ts`: `ServerConfig.httpEnabled` 제거
  - `apps/frontend/src/pages/Settings/sections/ServerSettings.tsx`: HTTP 활성화 토글 제거, WEB 포트 설정만 유지, WebDAV의 http 의존 조건 제거
  - `apps/frontend/src/stores/settingsStore.ts`: `httpEnabled`, `setHttpEnabled` 제거
- 기타
  - `.gitignore`: `**/config/secrets/` 추가
  - `docs/ai-context/*`: 상태/할일/의사결정 로그 동기화

## 범위
### In Scope
- 설정 모델/API/UI 정합성 확보 (`http_enabled` 제거)
- 시크릿 경로 Git ignore 보강
- AI 컨텍스트 문서 동기화

### Out of Scope
- TLS 내장 서버 구현
- SFTP 기본 정책 변경
- 신규 프로토콜(SMB/NFS) 구현

## 테스트/검증
- 자동 검증
  - `cd apps/backend && go test ./...` PASS
  - `pnpm -C apps/frontend lint` PASS
  - `pnpm -C apps/frontend exec tsc --noEmit` PASS
  - `pnpm -C apps/frontend build` PASS
- 수동 검증
  - 서버 설정 화면에서 HTTP 활성화 토글 제거 확인
  - WebDAV/SFTP 설정 섹션 정상 노출 확인

## 리스크 및 대응
- 잠재 리스크
  - 기존 설정 파일/클라이언트가 `http_enabled`를 포함해도 무시되므로 동작 영향은 제한적
- 모니터링 포인트
  - `/api/config` 응답/저장 시 프론트 역직렬화 오류 여부
- 롤백
  - 본 PR revert 시 기존 필드와 UI 토글 복구 가능

## 리뷰 가이드
- 우선 확인 파일
  - `apps/backend/internal/config/config_model.go`
  - `apps/backend/internal/config/handler.go`
  - `apps/frontend/src/pages/Settings/sections/ServerSettings.tsx`
  - `apps/frontend/src/api/config.ts`
  - `.gitignore`
- 확인 포인트
  - 설정 필드 제거 후 API/프론트 타입 정합성
  - WebDAV/SFTP 토글 동작 회귀 여부

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음