### PR TITLE
fix: cross-space 이동/복사 목적지 권한 검증 보완

### DIFF
--- a/apps/backend/internal/space/handler/file_handler_permission_test.go
+++ b/apps/backend/internal/space/handler/file_handler_permission_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"taeu.kr/cohesion/internal/account"
+	"taeu.kr/cohesion/internal/auth"
+)
+
+type fakeSpaceAccessService struct {
+	allowed          bool
+	err              error
+	called           bool
+	gotUsername      string
+	gotSpaceID       int64
+	gotPermissionReq account.Permission
+}
+
+func (f *fakeSpaceAccessService) CanAccessSpaceByID(ctx context.Context, username string, spaceID int64, required account.Permission) (bool, error) {
+	f.called = true
+	f.gotUsername = username
+	f.gotSpaceID = spaceID
+	f.gotPermissionReq = required
+	return f.allowed, f.err
+}
+
+func TestEnsureSpacePermission(t *testing.T) {
+	newRequest := func(withClaims bool) *http.Request {
+		req, err := http.NewRequest(http.MethodPost, "/api/spaces/1/files/move", nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		if !withClaims {
+			return req
+		}
+		claims := &auth.Claims{Username: "tester"}
+		return req.WithContext(auth.WithClaims(req.Context(), claims))
+	}
+
+	t.Run("unauthorized when claims missing", func(t *testing.T) {
+		fakeSvc := &fakeSpaceAccessService{}
+		h := &Handler{accountService: fakeSvc}
+
+		webErr := h.ensureSpacePermission(newRequest(false), 12, account.PermissionWrite)
+		if webErr == nil {
+			t.Fatal("expected unauthorized error")
+		}
+		if webErr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, webErr.Code)
+		}
+		if fakeSvc.called {
+			t.Fatal("account service must not be called when claims are missing")
+		}
+	})
+
+	t.Run("forbidden when account service denies access", func(t *testing.T) {
+		fakeSvc := &fakeSpaceAccessService{allowed: false}
+		h := &Handler{accountService: fakeSvc}
+
+		webErr := h.ensureSpacePermission(newRequest(true), 34, account.PermissionWrite)
+		if webErr == nil {
+			t.Fatal("expected forbidden error")
+		}
+		if webErr.Code != http.StatusForbidden {
+			t.Fatalf("expected status %d, got %d", http.StatusForbidden, webErr.Code)
+		}
+		if !fakeSvc.called {
+			t.Fatal("expected account service to be called")
+		}
+		if fakeSvc.gotUsername != "tester" {
+			t.Fatalf("expected username tester, got %s", fakeSvc.gotUsername)
+		}
+		if fakeSvc.gotSpaceID != 34 {
+			t.Fatalf("expected spaceID 34, got %d", fakeSvc.gotSpaceID)
+		}
+		if fakeSvc.gotPermissionReq != account.PermissionWrite {
+			t.Fatalf("expected required permission %s, got %s", account.PermissionWrite, fakeSvc.gotPermissionReq)
+		}
+	})
+
+	t.Run("internal server error when account service fails", func(t *testing.T) {
+		fakeSvc := &fakeSpaceAccessService{err: errors.New("db error")}
+		h := &Handler{accountService: fakeSvc}
+
+		webErr := h.ensureSpacePermission(newRequest(true), 56, account.PermissionWrite)
+		if webErr == nil {
+			t.Fatal("expected internal server error")
+		}
+		if webErr.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, webErr.Code)
+		}
+	})
+
+	t.Run("allow when account service grants access", func(t *testing.T) {
+		fakeSvc := &fakeSpaceAccessService{allowed: true}
+		h := &Handler{accountService: fakeSvc}
+
+		webErr := h.ensureSpacePermission(newRequest(true), 78, account.PermissionWrite)
+		if webErr != nil {
+			t.Fatalf("expected nil error, got %+v", webErr)
+		}
+	})
+}

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,16 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### cross-space 이동/복사 목적지 권한 검증 보완 정책 확정 (2026-02-21, #117)
+- **문제**:
+  - 인증 미들웨어의 Space 권한 검증은 URL의 source `spaceId` 기준으로만 동작한다.
+  - `move/copy`는 body의 `destination.spaceId`를 허용하지만, 기존 구현은 destination Space 쓰기 권한을 별도로 검증하지 않았다.
+- **결정**:
+  - `handleFileMove`/`handleFileCopy`에서 destination Space에 대한 `write` 권한 검증을 핸들러 레벨에서 추가한다.
+  - 공통 헬퍼(`ensureSpacePermission`)로 `claims` + `CanAccessSpaceByID` 검증 로직을 재사용한다.
+- **이유**:
+  - cross-space 쓰기 경로는 URL 기반 미들웨어만으로 완전하게 커버되지 않으므로, 목적지 리소스 권한을 액션 처리 지점에서 명시적으로 강제해야 보안 경계가 닫힌다.
+
 ### 다운로드 티켓 경로 2차(단일 다운로드 통일) 정책 확정 (2026-02-21)
 - **문제**:
   - 1차 도입 후에도 단일 다운로드는 여전히 `fetch -> blob` 경로를 사용해 메모리 피크 리스크가 남아 있었음.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,15 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **cross-space 이동/복사 목적지 Space 권한 검증 보완 완료** (2026-02-21, #117):
+    - 백엔드:
+      - `handleFileMove`/`handleFileCopy`에서 `destination.spaceId` 기준 `write` 권한 검증을 추가.
+      - 공통 헬퍼 `ensureSpacePermission`를 도입해 `claims` 기반 `CanAccessSpaceByID` 검증을 재사용.
+      - 권한 부족 시 `403 Forbidden`으로 차단하고, 권한 평가 실패 시 `500`을 반환.
+    - 테스트:
+      - `file_handler_permission_test.go` 추가 (`401/403/500/성공` 케이스 검증).
+    - 검증:
+      - `cd apps/backend && go test ./internal/space/handler ./internal/auth` 통과
 - **다운로드 티켓 경로 2차 적용 완료 (단일 다운로드 통일)** (2026-02-21):
     - 백엔드:
       - 단일 다운로드 티켓 액션 추가 (`POST /api/spaces/{id}/files/download-ticket`).

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -6,6 +6,7 @@
 - [ ] 프론트엔드 빌드 및 백엔드 임베딩 동작 확인
 
 ## 기능 구현 / 버그 수정
+- [x] cross-space 이동/복사 destination Space 권한 검증 보완 (`handleFileMove`/`handleFileCopy`에 destination `write` 권한 체크 + 단위 테스트 추가) (#117)
 - [x] 다운로드 티켓 경로 2차 적용 (단일 다운로드 `download-ticket` API + 단일/다중 네이티브 다운로드 통일)
 - [x] 다중/ZIP 다운로드 티켓 기반 네이티브 경로 1차 도입 (`download-multiple-ticket` + `/api/downloads/{ticket}` + 프론트 다중 다운로드 네이티브 전환)
 - [x] 데스크톱 다중선택 우클릭 카운트 표기 정렬 (항목별 `N개` 제거 + 메뉴 상단 `N개 선택됨` 요약 추가)


### PR DESCRIPTION
### 요약
- 문제
  - `move/copy`는 body의 `destination.spaceId`로 cross-space 작업이 가능하지만, 기존 권한 검증은 URL의 source space 기준이라 destination write 권한 공백이 있었습니다.
- 해결
  - `handleFileMove`/`handleFileCopy`에 destination Space `write` 권한 검증을 추가했습니다.
  - 공통 헬퍼 `ensureSpacePermission`를 도입해 `claims + CanAccessSpaceByID` 검증을 재사용합니다.
  - `401/403/500/성공` 케이스 단위 테스트를 추가했습니다.
- 기대 효과
  - destination Space 권한 없는 사용자의 cross-space 쓰기 요청이 서버에서 확실히 차단됩니다.

### 관련 이슈
- Closes #117

### 변경 사항
- 백엔드
  - `apps/backend/internal/space/handler/file_handler.go`
    - `ensureSpacePermission` 추가
    - `handleFileMove` destination `write` 권한 체크 추가
    - `handleFileCopy` destination `write` 권한 체크 추가
- 테스트
  - `apps/backend/internal/space/handler/file_handler_permission_test.go`
    - `ensureSpacePermission` 단위 테스트(`401/403/500/성공`) 추가
- 문서
  - `docs/ai-context/status.md`
  - `docs/ai-context/todo.md`
  - `docs/ai-context/decision_log.md`

### 범위
- In Scope
  - cross-space `move/copy` destination 권한 검증 보강
  - 관련 단위 테스트 및 ai-context 문서 동기화
- Out of Scope
  - RBAC 모델/스키마 변경
  - 프론트 권한 UI 정책 변경
  - 다운로드 경로 변경

### 테스트/검증
- 실행 명령어
  - `cd apps/backend && go test ./internal/space/handler ./internal/auth`
- 결과
  - PASS

### 리스크 및 대응
- 잠재 회귀
  - destination 권한 체크 강화로 기존에 권한이 불명확했던 요청이 `403`으로 거절될 수 있음(의도된 보안 강화)
- 롤백
  - 해당 커밋 revert 시 기존 동작으로 복원 가능

### 리뷰 가이드
- 우선 확인 파일
  - `apps/backend/internal/space/handler/file_handler.go`
  - `apps/backend/internal/space/handler/file_handler_permission_test.go`
  - `docs/ai-context/decision_log.md`

### 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 관련 이슈 링크 확인
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음