### PR TITLE
chore: 릴리즈 자동화 워크플로 및 릴리즈 노트 카테고리 추가

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  categories:
+    - title: "New Features"
+      labels:
+        - "feat"
+        - "feature"
+        - "enhancement"
+    - title: "Bug Fixes"
+      labels:
+        - "fix"
+        - "bug"
+        - "bugfix"
+    - title: "Maintenance (Chore)"
+      labels:
+        - "chore"
+        - "dependencies"
+        - "ci"
+        - "build"
+        - "refactor"
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.7"
+          cache: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.24.0
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run release config check
+        run: pnpm release:check
+
+      - name: Run backend tests
+        run: go test ./...
+        working-directory: apps/backend
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --config .goreleaser.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ builds:
       - -s -w -X main.goEnv=production
     goos:
       - darwin
+      - linux
       - windows
     goarch:
       - amd64

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,33 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### GitHub Actions 태그 기반 자동 릴리즈 파이프라인 확정 (2026-02-21)
+- **문제**:
+  - 태그를 푸시해도 릴리즈가 자동 실행되지 않아 운영자가 수동으로 GoReleaser를 실행해야 했다.
+- **결정**:
+  - `.github/workflows/release.yml`을 추가해 `v*` 태그 푸시 시 자동 릴리즈를 실행한다.
+  - 워크플로에서 `pnpm install`, `pnpm release:check`, 백엔드 테스트 후 `goreleaser release --clean`을 수행한다.
+- **이유**:
+  - 릴리즈 실행 경로를 태그 이벤트에 고정하면 배포 재현성과 운영 일관성을 높일 수 있고, 수동 실행 누락 리스크를 줄일 수 있다.
+
+### GitHub Release Notes 카테고리 구성 확정 (2026-02-21)
+- **문제**:
+  - 릴리즈 노트에 어떤 내용을 어떤 기준으로 쓸지 팀 기준이 없어서 버전별 메시지 품질 편차가 생길 수 있었다.
+- **결정**:
+  - `.github/release.yml`을 추가해 GitHub `Generate release notes` 기준 카테고리를 고정한다.
+  - 카테고리: `New Features`, `Bug Fixes`, `Maintenance (Chore)`, `Other Changes`.
+- **이유**:
+  - 과도한 장문 대신 사용자 관점 핵심 섹션으로 일관되게 요약하고, PR 라벨 기반 자동 분류로 릴리즈 작성 비용을 낮추기 위함.
+
+### GoReleaser 대상 플랫폼 표기/구성 확장 (2026-02-21)
+- **문제**:
+  - 기존 릴리즈 설정이 `darwin/windows`만 포함하여 Linux 사용자 대상 바이너리가 자동 생성되지 않았다.
+- **결정**:
+  - `.goreleaser.yaml`의 `goos`를 `darwin/linux/windows`로 확장하고, `goarch`는 기존 `amd64/arm64`를 유지한다.
+- **이유**:
+  - 배포 대상은 OS와 아키텍처를 함께 정의해야 실제 실행 호환성이 명확해진다.
+  - macOS/Linux/Windows 사용자군을 공통 커버하면서 현대 환경의 주력 아키텍처(`amd64`, `arm64`)를 동시에 지원하기 위함.
+
 ### cross-space 이동/복사 목적지 권한 검증 보완 정책 확정 (2026-02-21, #117)
 - **문제**:
   - 인증 미들웨어의 Space 권한 검증은 URL의 source `spaceId` 기준으로만 동작한다.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,25 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **GitHub Actions 태그 기반 자동 릴리즈 워크플로 추가 완료** (2026-02-21):
+    - 배포/CI:
+      - `.github/workflows/release.yml` 추가 (`push tags: v*`, `workflow_dispatch`).
+      - `ubuntu-latest`에서 `Go 1.25.7`, `Node 24`, `pnpm 10.24.0` 환경 구성 후 릴리즈 실행.
+      - 순서: `pnpm install` -> `pnpm release:check` -> `apps/backend go test ./...` -> `goreleaser release --clean`.
+      - GitHub 릴리즈/아티팩트 업로드를 위해 `permissions.contents: write` 설정.
+    - 검증:
+      - 로컬 `pnpm release:check` 통과 (`.goreleaser.yaml` 유효성 확인).
+- **GitHub Release Notes 카테고리 템플릿 적용 완료** (2026-02-21):
+    - 배포/문서:
+      - `.github/release.yml` 추가.
+      - 릴리즈 노트 자동 분류 카테고리를 `New Features / Bug Fixes / Maintenance (Chore) / Other Changes`로 구성.
+      - PR 라벨(`feat|feature|enhancement`, `fix|bug|bugfix`, `chore|dependencies|ci|build|refactor`) 기반 섹션 분류 정책 반영.
+- **GoReleaser 배포 대상 OS 확장 완료 (linux 추가)** (2026-02-21):
+    - 배포:
+      - `.goreleaser.yaml`의 `goos`에 `linux` 추가 (`darwin/linux/windows` 대상).
+      - 기존 `goarch`(`amd64`, `arm64`) 조합으로 Linux 아티팩트도 함께 생성되도록 확장.
+    - 검증:
+      - `pnpm release:check` 통과 (`.goreleaser.yaml` 유효성 확인)
 - **cross-space 이동/복사 목적지 Space 권한 검증 보완 완료** (2026-02-21, #117):
     - 백엔드:
       - `handleFileMove`/`handleFileCopy`에서 `destination.spaceId` 기준 `write` 권한 검증을 추가.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -6,6 +6,9 @@
 - [ ] 프론트엔드 빌드 및 백엔드 임베딩 동작 확인
 
 ## 기능 구현 / 버그 수정
+- [x] GitHub Actions 자동 릴리즈 워크플로 추가 (`.github/workflows/release.yml`, 태그 `v*` 트리거 + GoReleaser 실행)
+- [x] GitHub Release Notes 카테고리 템플릿 추가 (`.github/release.yml`: New Features/Bug Fixes/Maintenance(Chore)/Other Changes)
+- [x] GoReleaser 대상 OS 확장 (`darwin/windows` -> `darwin/linux/windows`, 아키텍처 `amd64/arm64` 유지)
 - [x] cross-space 이동/복사 destination Space 권한 검증 보완 (`handleFileMove`/`handleFileCopy`에 destination `write` 권한 체크 + 단위 테스트 추가) (#117)
 - [x] 다운로드 티켓 경로 2차 적용 (단일 다운로드 `download-ticket` API + 단일/다중 네이티브 다운로드 통일)
 - [x] 다중/ZIP 다운로드 티켓 기반 네이티브 경로 1차 도입 (`download-multiple-ticket` + `/api/downloads/{ticket}` + 프론트 다중 다운로드 네이티브 전환)


### PR DESCRIPTION
### 요약
- 태그(`v*`) 기반 GitHub Actions 자동 릴리즈 워크플로를 추가했습니다.
- GitHub Release Notes 자동 생성 카테고리(`New Features/Bug Fixes/Maintenance/Other`)를 추가했습니다.
- GoReleaser 배포 대상 OS에 Linux를 추가했습니다.

### 변경 사항
- `.github/workflows/release.yml`
  - `push.tags: v*` 트리거
  - Go/Node/pnpm 세팅 후 `pnpm release:check` + `go test ./...` + `goreleaser release`
- `.github/release.yml`
  - 릴리즈 노트 카테고리 분류 규칙 추가
- `.goreleaser.yaml`
  - `goos`에 `linux` 추가 (`darwin/linux/windows`)
- `docs/ai-context/*`
  - status/todo/decision_log 동기화

### 검증
- `pnpm release:check` 통과

### 영향
- 태그 푸시 시 GitHub Release 및 아티팩트 업로드 자동화
- 릴리즈 노트 품질 일관화
