### PR TITLE
chore: goreleaser 릴리즈 노트 생성 방식을 github-native로 전환

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,9 +51,4 @@ checksum:
   name_template: checksums.txt
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+  use: github-native

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,14 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### GoReleaser changelog 생성 모드 전환 (2026-02-21)
+- **문제**:
+  - `v0.1.0` 릴리즈 본문이 `.github/release.yml` 카테고리 대신 git 커밋 목록(`## Changelog`) 형태로 생성됨.
+- **결정**:
+  - `.goreleaser.yaml`의 `changelog`를 `use: github-native`로 전환한다.
+- **이유**:
+  - GitHub native release notes API를 사용해야 `.github/release.yml` 카테고리 규칙이 적용되며, 사람이 기대한 섹션형 릴리즈 노트를 자동 생성할 수 있다.
+
 ### GitHub Actions 태그 기반 자동 릴리즈 파이프라인 확정 (2026-02-21)
 - **문제**:
   - 태그를 푸시해도 릴리즈가 자동 실행되지 않아 운영자가 수동으로 GoReleaser를 실행해야 했다.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,12 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **GoReleaser 릴리즈 노트 생성 방식을 GitHub Native로 전환 완료** (2026-02-21):
+    - 배포:
+      - `.goreleaser.yaml`의 `changelog`를 `use: github-native`로 변경.
+      - 이후 태그 릴리즈부터 `.github/release.yml` 카테고리(`New Features/Bug Fixes/Maintenance/Other`)를 사용해 본문 생성.
+    - 검증:
+      - `pnpm release:check` 통과 (`.goreleaser.yaml` 유효성 확인)
 - **GitHub Actions 태그 기반 자동 릴리즈 워크플로 추가 완료** (2026-02-21):
     - 배포/CI:
       - `.github/workflows/release.yml` 추가 (`push tags: v*`, `workflow_dispatch`).

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -6,6 +6,7 @@
 - [ ] 프론트엔드 빌드 및 백엔드 임베딩 동작 확인
 
 ## 기능 구현 / 버그 수정
+- [x] GoReleaser changelog 생성 방식 전환 (`.goreleaser.yaml`: `changelog.use=github-native`, `.github/release.yml` 카테고리 반영)
 - [x] GitHub Actions 자동 릴리즈 워크플로 추가 (`.github/workflows/release.yml`, 태그 `v*` 트리거 + GoReleaser 실행)
 - [x] GitHub Release Notes 카테고리 템플릿 추가 (`.github/release.yml`: New Features/Bug Fixes/Maintenance(Chore)/Other Changes)
 - [x] GoReleaser 대상 OS 확장 (`darwin/windows` -> `darwin/linux/windows`, 아키텍처 `amd64/arm64` 유지)


### PR DESCRIPTION
### 요약
- GoReleaser의 changelog 생성 방식을 git 커밋 나열에서 GitHub native release notes로 전환했습니다.
- 이후 태그 릴리즈부터 `.github/release.yml` 카테고리 규칙이 적용됩니다.

### 변경 사항
- `.goreleaser.yaml`
  - `changelog.use: github-native` 적용
- `docs/ai-context/status.md`
- `docs/ai-context/todo.md`
- `docs/ai-context/decision_log.md`
  - 변경 이력 동기화

### 검증
- `pnpm release:check` 통과

### 기대 효과
- 릴리즈 본문이 `New Features / Bug Fixes / Maintenance (Chore) / Other Changes` 섹션형으로 자동 생성됨