### PR TITLE
fix: 프론트 typecheck 경로 표준화와 CI 검증 단계 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
+      - name: Run typecheck
+        run: pnpm typecheck
+
       - name: Run build
         run: pnpm build
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b --pretty false",
     "lint": "eslint .",
     "preview": "vite preview",
     "clean": "rm -rf dist node_modules .turbo"

--- a/apps/frontend/src/features/browse/components/FolderContent/TrashModal.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/TrashModal.tsx
@@ -39,7 +39,7 @@ const TrashModal: React.FC<TrashModalProps> = ({
         dataIndex: 'itemName',
         key: 'itemName',
         ellipsis: true,
-        render: (_, record) => (
+        render: (_: unknown, record: TrashItem) => (
           <AntSpace>
             {record.isDir ? <FolderFilled style={{ color: 'var(--app-folder-icon-color, #415a77)' }} /> : <FileOutlined />}
             <span>{record.itemName}</span>
@@ -71,7 +71,7 @@ const TrashModal: React.FC<TrashModalProps> = ({
         key: 'itemSize',
         width: 120,
         align: 'right',
-        render: (size: number, record) => (record.isDir ? '-' : formatSize(size)),
+        render: (size: number, record: TrashItem) => (record.isDir ? '-' : formatSize(size)),
       },
     ];
   }, []);

--- a/apps/frontend/src/features/browse/components/TrashExplorer.tsx
+++ b/apps/frontend/src/features/browse/components/TrashExplorer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { App, Button, Empty, Radio, Space as AntSpace, Table, Typography } from 'antd';
 import type { TableColumnsType } from 'antd';
-import { DeleteOutlined, RollbackOutlined } from '@ant-design/icons';
+import { DeleteOutlined, FolderFilled, RollbackOutlined } from '@ant-design/icons';
 import { apiFetch } from '@/api/client';
 import { toApiError } from '@/api/error';
 import { useBrowseStore } from '@/stores/browseStore';
@@ -480,9 +480,13 @@ const TrashExplorer: React.FC = () => {
         dataIndex: 'itemName',
         key: 'itemName',
         ellipsis: true,
-        render: (_, record) => (
+        render: (_: unknown, record: GlobalTrashItem) => (
           <AntSpace>
-            <FileTypeIcon filename={record.itemName} isDirectory={record.isDir} size={16} />
+            {record.isDir ? (
+              <FolderFilled style={{ color: 'var(--app-folder-icon-color, #415a77)', fontSize: 16 }} />
+            ) : (
+              <FileTypeIcon filename={record.itemName} size={16} />
+            )}
             <span>{record.itemName}</span>
           </AntSpace>
         ),
@@ -519,7 +523,7 @@ const TrashExplorer: React.FC = () => {
         key: 'itemSize',
         width: 120,
         align: 'right',
-        render: (size: number, record) => (record.isDir ? '-' : formatSize(size)),
+        render: (size: number, record: GlobalTrashItem) => (record.isDir ? '-' : formatSize(size)),
       },
     ];
   }, []);
@@ -562,7 +566,7 @@ const TrashExplorer: React.FC = () => {
       <div style={{ minHeight: 0, flex: 1 }}>
         <Table<GlobalTrashItem>
           size="small"
-          rowKey={(record) => record.rowKey}
+          rowKey={(record: GlobalTrashItem) => record.rowKey}
           dataSource={items}
           columns={columns}
           loading={loading || processing}

--- a/apps/frontend/src/pages/Settings/sections/SpaceSettings.tsx
+++ b/apps/frontend/src/pages/Settings/sections/SpaceSettings.tsx
@@ -210,7 +210,7 @@ const SpaceSettings = () => {
       >
         <Table<SpaceUsageItem>
           size="small"
-          rowKey={(item) => item.spaceId}
+          rowKey={(item: SpaceUsageItem) => item.spaceId}
           loading={usageLoading}
           columns={spaceUsageColumns}
           dataSource={spaceUsages}

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,26 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### 프론트 타입 검증 명령 표준화 (`tsc -b`) 및 CI 단계 분리 (2026-02-23)
+- **문제**:
+  - `pnpm -C apps/frontend exec tsc --noEmit`는 루트 `tsconfig` references 구조에서 CI의 실제 빌드 경로(`tsc -b`)와 동일하지 않아, 일부 타입 오류를 사전에 놓칠 수 있었다.
+- **결정**:
+  - 프론트 패키지에 `typecheck` 스크립트(`tsc -b --pretty false`)를 추가한다.
+  - 루트 스크립트로 `pnpm typecheck`를 제공해 동일 경로를 단일 명령으로 실행 가능하게 한다.
+  - CI에 `Run typecheck` 단계를 `Run lint` 다음에 명시적으로 추가한다.
+- **이유**:
+  - lint/타입체크/빌드의 책임을 분리하면서도, 타입 검증은 CI 빌드와 동일한 컴파일 경로를 강제해 누락 위험을 줄이기 위함.
+
+### 프론트 타입 오류 정리(휴지통/설정 테이블) (2026-02-23)
+- **문제**:
+  - `typecheck(tsc -b)` 적용 후 휴지통/설정 테이블 렌더 콜백에서 `implicit any`와 `FileTypeIcon` prop 불일치가 드러났다.
+- **결정**:
+  - `TrashModal`, `TrashExplorer`의 `render`/`rowKey` 콜백에 명시 타입을 부여한다.
+  - `TrashExplorer`의 디렉터리 아이콘 렌더를 `FileTypeIcon` prop 계약에 맞게 분기(`FolderFilled` vs `FileTypeIcon`) 처리한다.
+  - `SpaceSettings` `rowKey` 콜백 파라미터 타입을 명시한다.
+- **이유**:
+  - CI 타입체크 통과를 복구하면서도 런타임 동작을 바꾸지 않는 최소 수정으로 안정성을 확보하기 위함.
+
 ### 휴지통 트리 `noop switcher` 여백 제거 방식 확정 (2026-02-23)
 - **문제**:
   - `휴지통` 항목은 leaf 노드지만, `.folder-tree .ant-tree-switcher` 공통 규칙이 동일하게 적용되어 `ant-tree-switcher-noop` 슬롯 폭(20px)이 남아 아이콘 좌측 여백이 과도했다.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,19 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **프론트 타입체크 명령/CI 검증 경로 정합화 (2026-02-23)**:
+    - 프론트:
+      - `apps/frontend/package.json`에 `typecheck` 스크립트(`tsc -b --pretty false`) 추가.
+      - 루트 `package.json`에 `typecheck` 스크립트(`pnpm -C apps/frontend typecheck`) 추가.
+      - `TrashModal`, `TrashExplorer`, `SpaceSettings`의 `implicit any` 및 아이콘 prop 타입 불일치 수정.
+    - CI:
+      - `.github/workflows/ci.yml`의 `Run lint` 다음에 `Run typecheck` 단계 추가.
+    - 검증:
+      - `pnpm -C apps/frontend lint` 통과.
+      - `pnpm -C apps/frontend typecheck` 통과.
+      - `pnpm typecheck` 통과.
+      - `pnpm -C apps/frontend build` 통과.
+
 - **사이드패널 휴지통 진입점 스타일 통합 (2026-02-23)**:
     - 프론트:
       - `SidePanelShell` footer 버튼 방식을 제거하고, 스페이스 트리 하단에 트리 스타일의 `휴지통` 항목을 배치.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -9,6 +9,8 @@
 - [x] 백엔드 테스트 최소 세트 확장 (`auth/service_test`, `auth/middleware_test`, `account/service_permissions_test`, `auth/test_helpers_test`)
 - [x] 프론트 탐색 상태 처리 일관화 (로딩/에러/빈 상태 UI + 재시도 동선 정리, `api/error.ts` 추가)
 - [x] PR CI 기본 파이프라인 추가 (`.github/workflows/ci.yml`, `lint + build + go test`)
+- [x] 프론트 `typecheck` 스크립트 추가 및 CI에 `Run typecheck` 단계 반영 (`tsc -b` 경로 표준화)
+- [x] 프론트 타입체크 오류 정리 (`TrashModal`/`TrashExplorer`/`SpaceSettings` 콜백 타입 및 아이콘 prop 정합)
 - [x] `v0.1.0` 릴리즈 노트 문서 작성 (`docs/releases/v0.1.0.md`, 영문 카테고리 기반)
 - [x] README 영문화 (섹션 구조/명령어 유지, 설명 문구 영어 전환)
 - [x] GoReleaser changelog 생성 방식 전환 (`.goreleaser.yaml`: `changelog.use=github-native`, `.github/release.yml` 카테고리 반영)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
+    "typecheck": "pnpm -C apps/frontend typecheck",
     "release:check": "go run github.com/goreleaser/goreleaser/v2@v2.13.3 check --config .goreleaser.yaml",
     "release:snapshot": "go run github.com/goreleaser/goreleaser/v2@v2.13.3 release --snapshot --clean --config .goreleaser.yaml",
     "lint": "turbo lint",


### PR DESCRIPTION
## 요약
### 문제
- 로컬에서 `lint` + `tsc --noEmit`만 확인하면 references 기반 프로젝트에서 CI 빌드 경로(`tsc -b`) 타입 오류를 놓칠 수 있었습니다.
- 실제로 휴지통/설정 테이블의 `implicit any`와 아이콘 prop 타입 불일치가 머지 이후 CI에서 드러났습니다.

### 해결
- `apps/frontend`에 `typecheck` 스크립트(`tsc -b --pretty false`)를 추가했습니다.
- 루트에 `pnpm typecheck` 스크립트를 추가해 동일 검증 경로를 공통화했습니다.
- CI에 `Run typecheck` 단계를 `Run lint` 다음으로 추가했습니다.
- 드러난 타입 오류(`TrashModal`, `TrashExplorer`, `SpaceSettings`)를 최소 수정으로 정리했습니다.

### 기대 효과
- 타입 오류를 `build` 이전 단계에서 선제 검출
- 로컬/CI 타입검증 경로 일치로 재현성 향상

## 관련 이슈
- Closes #135

## 변경 사항
- 스크립트
  - `apps/frontend/package.json`: `typecheck` 추가
  - `package.json`: 루트 `typecheck` 추가
- CI
  - `.github/workflows/ci.yml`: `Run typecheck` 단계 추가
- 타입 수정
  - `apps/frontend/src/features/browse/components/FolderContent/TrashModal.tsx`
  - `apps/frontend/src/features/browse/components/TrashExplorer.tsx`
  - `apps/frontend/src/pages/Settings/sections/SpaceSettings.tsx`
- 문서
  - `docs/ai-context/status.md`
  - `docs/ai-context/decision_log.md`
  - `docs/ai-context/todo.md`

## 범위
### In Scope
- 프론트 타입검증 명령 표준화
- CI 타입검증 단계 추가
- 관련 타입 오류 최소 수정

### Out of Scope
- ESLint type-aware 전면 전환
- 백엔드 파이프라인 구조 변경

## 테스트/검증
- `pnpm -C apps/frontend lint` ✅
- `pnpm -C apps/frontend typecheck` ✅
- `pnpm -C apps/frontend build` ✅
- `pnpm typecheck` ✅
- `cd apps/backend && go test ./...` ✅

## 리스크 및 대응
- 리스크: CI 시간 소폭 증가
- 대응: 타입 오류를 빌드 이전에 차단해 전체 실패 비용을 감소
- 롤백: 스크립트/워크플로우 변경 커밋 revert로 원복 가능

## 리뷰 가이드
1. `.github/workflows/ci.yml`
2. `apps/frontend/package.json`
3. `package.json`
4. `apps/frontend/src/features/browse/components/TrashExplorer.tsx`
5. `apps/frontend/src/features/browse/components/FolderContent/TrashModal.tsx`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료 (인증/권한/민감정보 경로 변경 없음)
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix` 예정)
- [x] 관련 이슈 링크 확인 (`Closes #135`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음