### PR TITLE
docs: README에 릴리즈 산출물 실행 가이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,46 @@ pnpm release:check
 pnpm release:snapshot
 ```
 
+### Supported OS / Architecture (Release Artifacts)
+
+| OS | Architecture | Artifact Format |
+| --- | --- | --- |
+| macOS | `amd64`, `arm64` | `.tar.gz` |
+| Linux | `amd64`, `arm64` | `.tar.gz` |
+| Windows | `amd64` | `.zip` |
+
+Release artifacts are published on GitHub Releases:
+
+- https://github.com/lteawoo/Cohesion/releases
+
+### Run from Release Artifact
+
+1. Download the artifact that matches your OS/architecture.
+2. Extract it.
+3. Run the binary.
+
+macOS / Linux:
+
+```bash
+tar -xzf cohesion_<version>_<os>_<arch>.tar.gz
+cd cohesion_<version>_<os>_<arch>
+./cohesion
+```
+
+Windows (PowerShell):
+
+```powershell
+Expand-Archive .\cohesion_<version>_windows_amd64.zip .
+.\cohesion.exe
+```
+
+On first run, Cohesion creates a default config file when missing. The default production config uses `data/cohesion.db` for SQLite, and secret files are generated locally when needed.
+
+### Upgrade Notes
+
+- Stop the running process before replacing the binary.
+- Keep your existing `config/` and `data/` directories to preserve settings and data.
+
 ## Environment Variables
 
 - `COHESION_JWT_SECRET`

--- a/docs/ai-context/decision_log.md
+++ b/docs/ai-context/decision_log.md
@@ -55,6 +55,15 @@
 - **특수 케이스**: `showBaseDirectories` 플래그로 모달에서는 시스템 디렉토리 탐색 가능.
 
 ## 개발 프로세스
+### README에 릴리즈 사용자 가이드(지원 OS/실행법) 명시 (2026-02-23)
+- **문제**:
+  - README에는 릴리즈 산출물 생성 명령만 있었고, 최종 사용자가 GitHub Releases 산출물을 받아 실행하는 방법과 OS 지원 범위가 명시돼 있지 않았다.
+- **결정**:
+  - README에 `Supported OS / Architecture (Release Artifacts)` 섹션을 추가한다.
+  - 릴리즈 산출물 실행 방법(macOS/Linux, Windows)과 업그레이드 시 주의사항(설정/데이터 디렉토리 유지)을 명시한다.
+- **이유**:
+  - 릴리즈 소비자 관점의 초기 실행 진입 장벽을 낮추고, 반복 문의를 줄여 운영 문서 품질을 높이기 위함.
+
 ### 프론트 타입 검증 명령 표준화 (`tsc -b`) 및 CI 단계 분리 (2026-02-23)
 - **문제**:
   - `pnpm -C apps/frontend exec tsc --noEmit`는 루트 `tsconfig` references 구조에서 CI의 실제 빌드 경로(`tsc -b`)와 동일하지 않아, 일부 타입 오류를 사전에 놓칠 수 있었다.

--- a/docs/ai-context/status.md
+++ b/docs/ai-context/status.md
@@ -1,6 +1,14 @@
 # 프로젝트 상태 (Status)
 
 ## 현재 진행 상황
+- **README 릴리즈 산출물 가이드 보강 (2026-02-23)**:
+    - 문서:
+      - `Supported OS / Architecture (Release Artifacts)` 섹션 추가.
+      - GitHub Releases 링크 및 산출물 실행 방법(macOS/Linux, Windows) 추가.
+      - 첫 실행 시 기본 설정/DB 경로 관련 안내와 업그레이드 시 주의사항(설정/데이터 디렉토리 유지) 추가.
+      - 구현 파일:
+        - `README.md`
+
 - **프론트 타입체크 명령/CI 검증 경로 정합화 (2026-02-23)**:
     - 프론트:
       - `apps/frontend/package.json`에 `typecheck` 스크립트(`tsc -b --pretty false`) 추가.

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -13,6 +13,7 @@
 - [x] 프론트 타입체크 오류 정리 (`TrashModal`/`TrashExplorer`/`SpaceSettings` 콜백 타입 및 아이콘 prop 정합)
 - [x] `v0.1.0` 릴리즈 노트 문서 작성 (`docs/releases/v0.1.0.md`, 영문 카테고리 기반)
 - [x] README 영문화 (섹션 구조/명령어 유지, 설명 문구 영어 전환)
+- [x] README에 릴리즈 산출물 실행 가이드 및 지원 OS/아키텍처 표기 추가
 - [x] GoReleaser changelog 생성 방식 전환 (`.goreleaser.yaml`: `changelog.use=github-native`, `.github/release.yml` 카테고리 반영)
 - [x] GitHub Actions 자동 릴리즈 워크플로 추가 (`.github/workflows/release.yml`, 태그 `v*` 트리거 + GoReleaser 실행)
 - [x] GitHub Release Notes 카테고리 템플릿 추가 (`.github/release.yml`: New Features/Bug Fixes/Maintenance(Chore)/Other Changes)


### PR DESCRIPTION
## 요약
### 문제
- README에는 릴리즈 산출물 생성 명령만 있고, 실제 릴리즈 사용자가 필요한 실행 가이드와 지원 OS 정보가 부족했습니다.

### 해결
- README에 릴리즈 산출물 기준 지원 OS/아키텍처 표를 추가했습니다.
- GitHub Releases 링크와 OS별 실행 예시(macOS/Linux, Windows)를 추가했습니다.
- 업그레이드 시 설정/데이터 디렉토리 유지 주의사항을 추가했습니다.

### 기대 효과
- 릴리즈 사용자 진입 장벽 감소
- 실행/업그레이드 관련 반복 문의 감소

## 관련 이슈
- Closes #137

## 변경 사항
- `README.md`
  - `Supported OS / Architecture (Release Artifacts)` 섹션 추가
  - 릴리즈 다운로드 링크 추가
  - 산출물 실행 방법 추가
  - `Upgrade Notes` 추가
- 컨텍스트 문서 업데이트
  - `docs/ai-context/status.md`
  - `docs/ai-context/decision_log.md`
  - `docs/ai-context/todo.md`

## 범위
### In Scope
- 릴리즈 산출물 사용자 가이드 문서화

### Out of Scope
- GoReleaser 설정/산출물 정책 변경
- 릴리즈 워크플로우 변경

## 테스트/검증
- 문서 변경으로 코드 빌드/테스트는 생략
- 수동 검증
  - README에 명시한 OS/아키텍처가 `v0.3.0` 릴리즈 산출물과 일치함 확인
  - 실행 예시 명령어 문법 확인

## 리스크 및 대응
- 리스크: 향후 산출물 정책 변경 시 README 불일치 가능
- 대응: 릴리즈 정책 변경 PR에 README 동시 갱신 체크 항목 유지
- 롤백: 문서 변경 커밋 revert

## 리뷰 가이드
1. `README.md`
2. `docs/ai-context/status.md`
3. `docs/ai-context/decision_log.md`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료 (문서 변경만 수행)
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`chore` 예정)
- [x] 관련 이슈 링크 확인 (`Closes #137`)
- [x] 영향 범위 점검
- [x] 문서 업데이트 완료
- [x] 브레이킹 변경 없음