### PR TITLE
fix: Windows browse 경로 정규화 계층 보강

### DIFF
--- a/apps/backend/internal/browse/service_test.go
+++ b/apps/backend/internal/browse/service_test.go
@@ -1,0 +1,106 @@
+package browse
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeBrowsePathWindowsDriveRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"C:":    `C:\`,
+		"c:":    `C:\`,
+		"C:\\":  `C:\`,
+		"C:/":   `C:\`,
+		"C:.":   `C:\`,
+		"C:\\.": `C:\`,
+	}
+
+	for input, expected := range tests {
+		input := input
+		expected := expected
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			if actual := normalizeBrowsePathForOS(input, "windows"); actual != expected {
+				t.Fatalf("normalizeBrowsePath(%q) = %q, want %q", input, actual, expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeBrowsePathWindowsDriveRelative(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		`C:Users`:        `C:\Users`,
+		`c:Users\Public`: `C:\Users\Public`,
+		`D:temp\..\logs`: `D:\logs`,
+		`e:.\downloads`:  `E:\downloads`,
+		`F:..\workspace`: `F:\workspace`,
+	}
+
+	for input, expected := range tests {
+		input := input
+		expected := expected
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			if actual := normalizeBrowsePathForOS(input, "windows"); actual != expected {
+				t.Fatalf("normalizeBrowsePath(%q) = %q, want %q", input, actual, expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeBrowsePathWindowsUNC(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		`\\server\share`:            `\\server\share`,
+		`\\server\share\folder`:     `\\server\share\folder`,
+		`\\server\share\foo\..\bar`: `\\server\share\bar`,
+		`//server/share/a/./b/../c`: `\\server\share\a\c`,
+	}
+
+	for input, expected := range tests {
+		input := input
+		expected := expected
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			if actual := normalizeBrowsePathForOS(input, "windows"); actual != expected {
+				t.Fatalf("normalizeBrowsePath(%q) = %q, want %q", input, actual, expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeBrowsePathForNonWindows(t *testing.T) {
+	t.Parallel()
+
+	input := "/tmp/../var//log"
+	expected := "/var/log"
+	if actual := normalizeBrowsePathForOS(input, "linux"); actual != expected {
+		t.Fatalf("normalizeBrowsePathForOS(%q, linux) = %q, want %q", input, actual, expected)
+	}
+}
+
+func TestNormalizeBrowsePathForNonWindowsPreservesWhitespace(t *testing.T) {
+	t.Parallel()
+
+	input := " /tmp/project "
+	expected := filepath.Clean(input)
+	if actual := normalizeBrowsePathForOS(input, "linux"); actual != expected {
+		t.Fatalf("normalizeBrowsePathForOS(%q, linux) = %q, want %q", input, actual, expected)
+	}
+}
+
+func TestMountpointDedupKeyByOS(t *testing.T) {
+	t.Parallel()
+
+	if actual := mountpointDedupKey(`C:\`, "windows"); actual != `c:\` {
+		t.Fatalf("mountpointDedupKey windows = %q, want %q", actual, `c:\`)
+	}
+	if actual := mountpointDedupKey("/Volumes/Data", "darwin"); actual != "/Volumes/Data" {
+		t.Fatalf("mountpointDedupKey darwin = %q, want %q", actual, "/Volumes/Data")
+	}
+}

--- a/docs/ai-context/todo.md
+++ b/docs/ai-context/todo.md
@@ -156,6 +156,7 @@
   - [ ] 검색 결과 키워드 하이라이트
 - [x] 스페이스 0개 + 휴지통 경로에서 Space 생성 모달 트리 확장 불가 루프 수정 (`TrashExplorer` fetch 루프 제거 + `FolderTree` 초기화 effect 분리)
 - [x] 스페이스 0개에서도 `/trash` 기본 레이아웃 유지 + `/trash`에서 동일 Space 재클릭 시 `/` 전환 보장 (`FolderTree` same-selection guard 우회 옵션)
+- [x] Windows browse 경로 정규화 계층 보강 (`C:` 루트/drive-relative/UNC 경로를 일관 정규화해 드라이브 하위 폴더 조회 오차 방지)
 - [x] DB 삭제/재생성 후 stale JWT 세션 차단 (미들웨어 사용자 실체 검증 + refresh 경로 동일 검증 + 회귀 테스트)
 - [x] 실행파일 루트 로그 통합 (`logs/app.log`, `logs/updater.log` 생성 및 업데이터 재시작 stdout/stderr 리다이렉트)
 - [x] 실행파일 루트 PID 파일(`cohesion.pid`) 기록 + 릴리즈용 shutdown 스크립트(`stop-cohesion.command`, `stop-cohesion.bat`) 추가


### PR DESCRIPTION
## 요약
문제:
- Windows에서 `C:`는 `C:\`와 다르게 drive-relative로 해석되어, browse API가 의도와 다른 디렉터리를 조회할 수 있었습니다.
- 입력 경로가 `C:foo`, `C:/foo`, UNC(`\\server\share`) 등으로 혼재할 때 해석 일관성이 부족했습니다.
- mountpoint dedupe가 전역 소문자 비교여서 non-Windows의 case-sensitive 경로 의미를 훼손할 여지가 있었습니다.

해결:
- `browse.Service`에 OS별 정규화 계층(`normalizeBrowsePathForOS`)을 도입했습니다.
- Windows 전용 파서에서 drive root/drive-relative/UNC를 분리 처리하도록 구현했습니다.
- mountpoint dedupe 키를 OS별로 분리해 Windows만 case-insensitive 처리하고, non-Windows는 원문을 유지하도록 조정했습니다.
- 정규화 테스트를 root/drive-relative/UNC/non-Windows/OS별 dedupe까지 확장했습니다.

기대 효과:
- Windows 드라이브 루트 하위 조회 정확도 향상
- 경로 입력 형태 차이에 대한 탐색 결과 일관성 확보
- non-Windows 경로 의미 보존

## 관련 이슈
Closes #150

## 변경 사항
- backend browse 경로 정규화 계층 추가
  - `apps/backend/internal/browse/service.go`
- backend browse 정규화 테스트 추가/확장
  - `apps/backend/internal/browse/service_test.go`
- 컨텍스트 문서 업데이트
  - `docs/ai-context/status.md`
  - `docs/ai-context/todo.md`
  - `docs/ai-context/decision_log.md`

## 범위
In Scope:
- Windows browse 경로 파싱/정규화
- mountpoint dedupe 정책 OS별 분리
- 관련 단위 테스트/문서 갱신

Out of Scope:
- 프론트엔드 browse UI 변경
- space browse 권한 정책 변경
- Windows CI 매트릭스 추가

## 테스트/검증
- `cd apps/backend && go test ./internal/browse/...` PASS
- `cd apps/backend && go test ./...` PASS

## 리스크 및 대응
- 리스크: Windows 경로 정규화 규칙 변경으로 일부 기존 입력(`C:foo`)의 해석이 달라질 수 있음
- 대응: drive-relative를 루트 기준 절대경로로 강제하는 정책을 명시하고, 해당 케이스를 테스트로 고정
- 롤백: `normalizeBrowsePathForOS` 도입 이전 구현으로 복귀 가능

## 리뷰 가이드
1. `apps/backend/internal/browse/service.go`
2. `apps/backend/internal/browse/service_test.go`
3. `docs/ai-context/decision_log.md`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #150`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음