### PR TITLE
feat: 파일 활성화 제스처 정책 보강 및 모바일 단일탭 선택 적용

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b --pretty false",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview",
     "clean": "rm -rf dist node_modules .turbo"
   },
@@ -24,6 +25,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -33,8 +36,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^28.1.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.48.1",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/frontend/src/features/browse/components/FolderContent.test.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent.test.tsx
@@ -1,0 +1,484 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FolderContent from './FolderContent';
+
+const h = vi.hoisted(() => {
+  const mockNavigate = vi.fn();
+  const mockSetPath = vi.fn();
+  const mockFetchSpaceContents = vi.fn();
+  const mockClearTrashOpenRequest = vi.fn();
+  const mockHandleBulkDownload = vi.fn();
+  const mockHandleItemClick = vi.fn();
+  const mockSetSelection = vi.fn();
+  const mockClearSelection = vi.fn();
+  const mockOpenSearchResult = vi.fn();
+  const locationPathState = { pathname: '/browse' };
+  const breakpointState = { lg: true };
+  const selectedSpace = { id: 1, name: 'Workspace' };
+  const contentItems = [
+    {
+      name: 'docs',
+      path: '/docs',
+      isDir: true,
+      modTime: '2026-03-01T00:00:00.000Z',
+      size: 0,
+    },
+    {
+      name: 'report.pdf',
+      path: '/report.pdf',
+      isDir: false,
+      modTime: '2026-03-01T00:00:00.000Z',
+      size: 2048,
+    },
+  ];
+  const storeState = {
+    selectedPath: '/',
+    selectedSpace,
+    content: contentItems,
+    isLoading: false,
+    error: null,
+    setPath: mockSetPath,
+    fetchSpaceContents: mockFetchSpaceContents,
+    trashOpenRequest: null,
+    clearTrashOpenRequest: mockClearTrashOpenRequest,
+  };
+  const useBrowseStoreMock = vi.fn((selector: (state: typeof storeState) => unknown) => selector(storeState));
+  (useBrowseStoreMock as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+  return {
+    mockNavigate,
+    mockSetPath,
+    mockFetchSpaceContents,
+    mockHandleBulkDownload,
+    mockHandleItemClick,
+    mockSetSelection,
+    mockClearSelection,
+    mockOpenSearchResult,
+    locationPathState,
+    breakpointState,
+    selectedSpace,
+    contentItems,
+    storeState,
+    useBrowseStoreMock,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router', () => ({
+  useLocation: () => ({ pathname: h.locationPathState.pathname, state: null }),
+  useNavigate: () => h.mockNavigate,
+}));
+
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('antd');
+  return {
+    ...actual,
+    App: {
+      useApp: () => ({
+        message: {
+          error: vi.fn(),
+        },
+      }),
+    },
+    Grid: {
+      useBreakpoint: () => h.breakpointState,
+    },
+    theme: {
+      useToken: () => ({ token: {} }),
+    },
+  };
+});
+
+vi.mock('@/stores/browseStore', () => ({
+  useBrowseStore: h.useBrowseStoreMock,
+}));
+
+vi.mock('@/features/auth/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      permissions: ['file.write'],
+    },
+  }),
+}));
+
+vi.mock('../hooks/useFileSelection', () => ({
+  useFileSelection: () => ({
+    selectedItems: new Set<string>(),
+    handleItemClick: h.mockHandleItemClick,
+    setSelection: h.mockSetSelection,
+    clearSelection: h.mockClearSelection,
+  }),
+}));
+
+vi.mock('../hooks/useBreadcrumb', () => ({
+  useBreadcrumb: () => ({
+    breadcrumbItems: [{ key: 'root', title: 'root' }],
+  }),
+}));
+
+vi.mock('../hooks/useFileOperations', () => ({
+  useFileOperations: () => ({
+    handleRename: vi.fn(),
+    handleCreateFolder: vi.fn(),
+    handleDelete: vi.fn(),
+    handleBulkDelete: vi.fn(),
+    fetchTrashItems: vi.fn(),
+    handleTrashRestore: vi.fn(),
+    handleTrashDelete: vi.fn(),
+    handleTrashEmpty: vi.fn(),
+    handleMove: vi.fn(),
+    handleCopy: vi.fn(),
+    handleBulkDownload: h.mockHandleBulkDownload,
+    handleFileUpload: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useDragAndDrop', () => ({
+  useDragAndDrop: () => ({
+    isDragging: false,
+    dragOverFolder: null,
+    handleItemDragStart: vi.fn(),
+    handleItemDragEnd: vi.fn(),
+    handleFolderDragOver: vi.fn(),
+    handleFolderDragLeave: vi.fn(),
+    handleFolderDrop: vi.fn(),
+    handleDragEnter: vi.fn(),
+    handleDragLeave: vi.fn(),
+    handleDragOver: vi.fn(),
+    handleDrop: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useContextMenu', () => ({
+  useContextMenu: () => ({
+    handleContextMenu: vi.fn(),
+    handleEmptyAreaContextMenu: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useBoxSelection', () => ({
+  useBoxSelection: () => ({
+    isSelecting: false,
+    selectionBox: null,
+    wasRecentlySelecting: false,
+  }),
+}));
+
+vi.mock('../hooks/useModalManager', () => ({
+  useModalManager: () => ({
+    modals: {
+      destination: { visible: false, data: { mode: 'copy', sources: [] } },
+      rename: { visible: false, data: { record: null, newName: '' } },
+      createFolder: { visible: false, data: { folderName: '' } },
+    },
+    openModal: vi.fn(),
+    closeModal: vi.fn(),
+    updateModalData: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSortedContent', () => ({
+  useSortedContent: (content: unknown[]) => content,
+}));
+
+vi.mock('../hooks/useBrowseHistoryNavigation', () => ({
+  useBrowseHistoryNavigation: () => ({
+    canGoBack: false,
+    canGoForward: false,
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSearchModeContent', () => ({
+  useSearchModeContent: ({ browseContent, browseErrorMessage, browseLoading }: {
+    browseContent: unknown[];
+    browseErrorMessage: string | null;
+    browseLoading: boolean;
+  }) => ({
+    searchSource: { query: '', hasEnoughQuery: false },
+    sourceContent: browseContent,
+    openSearchResultByRecordPath: h.mockOpenSearchResult,
+    renderSearchName: (record: { name: string }) => record.name,
+    renderSearchMeta: () => null,
+    activeErrorMessage: browseErrorMessage,
+    activeLoading: browseLoading,
+  }),
+}));
+
+vi.mock('../hooks/useTrashModalManager', () => ({
+  useTrashModalManager: () => ({
+    isTrashModalOpen: false,
+    trashItems: [],
+    selectedTrashIds: [],
+    isTrashLoading: false,
+    isTrashProcessing: false,
+    setSelectedTrashIds: vi.fn(),
+    handleCloseTrash: vi.fn(),
+    handleTrashRestoreConfirm: vi.fn(),
+    handleTrashDeleteConfirm: vi.fn(),
+    handleTrashEmptyConfirm: vi.fn(),
+  }),
+}));
+
+vi.mock('./FolderContent/FolderContentToolbar', () => ({
+  default: () => <div data-testid="toolbar" />,
+}));
+
+vi.mock('./FolderContent/FolderContentTable', () => ({
+  default: ({ dataSource, onItemClick, onItemDoubleClick, onItemTouchStart, onItemTouchEnd, onItemTouchCancel }: {
+    dataSource: Array<{ path: string; name: string }>;
+    onItemClick: (event: ReactMouseEvent<HTMLElement>, record: { path: string; name: string }, index: number) => void;
+    onItemDoubleClick: (path: string) => void;
+    onItemTouchStart?: (record: { path: string; name: string }, index: number) => void;
+    onItemTouchEnd?: () => void;
+    onItemTouchCancel?: () => void;
+  }) => (
+    <div>
+      {dataSource.map((item, index) => (
+        <button
+          key={item.path}
+          type="button"
+          onClick={(event) => onItemClick(event, item, index)}
+          onDoubleClick={() => onItemDoubleClick(item.path)}
+          onTouchStart={() => onItemTouchStart?.(item, index)}
+          onTouchEnd={() => onItemTouchEnd?.()}
+          onTouchCancel={() => onItemTouchCancel?.()}
+        >
+          {item.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./FolderContent/FolderContentGrid', () => ({
+  default: ({ dataSource, onItemClick, onItemDoubleClick, onItemTouchStart, onItemTouchEnd, onItemTouchCancel }: {
+    dataSource: Array<{ path: string; name: string }>;
+    onItemClick: (event: ReactMouseEvent<HTMLElement>, record: { path: string; name: string }, index: number) => void;
+    onItemDoubleClick: (path: string) => void;
+    onItemTouchStart?: (record: { path: string; name: string }, index: number) => void;
+    onItemTouchEnd?: () => void;
+    onItemTouchCancel?: () => void;
+  }) => (
+    <div>
+      {dataSource.map((item, index) => (
+        <button
+          key={item.path}
+          type="button"
+          onClick={(event) => onItemClick(event, item, index)}
+          onDoubleClick={() => onItemDoubleClick(item.path)}
+          onTouchStart={() => onItemTouchStart?.(item, index)}
+          onTouchEnd={() => onItemTouchEnd?.()}
+          onTouchCancel={() => onItemTouchCancel?.()}
+        >
+          {item.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('./DestinationPickerModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('./FolderContent/RenameModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('./FolderContent/CreateFolderModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('./FolderContent/TrashModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('./FolderContent/UploadOverlay', () => ({
+  default: () => null,
+}));
+
+vi.mock('./FolderContent/BoxSelectionOverlay', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/common/BottomSheet', () => ({
+  default: () => null,
+}));
+
+function setTouchSupport(enabled: boolean) {
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: enabled ? 2 : 0,
+  });
+}
+
+function setMobileLayout(enabled: boolean) {
+  h.breakpointState.lg = !enabled;
+}
+
+function dispatchTouchEvent(
+  element: Element,
+  type: 'touchstart' | 'touchend' | 'touchcancel',
+  touches: Array<{ clientX: number; clientY: number }>
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as Event & {
+    touches: Array<{ clientX: number; clientY: number }>;
+    changedTouches: Array<{ clientX: number; clientY: number }>;
+  };
+  Object.defineProperty(event, 'touches', { configurable: true, value: touches });
+  Object.defineProperty(event, 'changedTouches', { configurable: true, value: touches });
+  element.dispatchEvent(event);
+}
+
+describe('FolderContent activation behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.storeState.content = h.contentItems;
+    h.locationPathState.pathname = '/browse';
+    setMobileLayout(false);
+    setTouchSupport(false);
+  });
+
+  it('opens folder path on desktop double click', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(<FolderContent />);
+
+    await user.dblClick(getByRole('button', { name: 'docs' }));
+
+    expect(h.mockSetPath).toHaveBeenCalledWith('/docs', h.selectedSpace);
+    expect(h.mockHandleBulkDownload).not.toHaveBeenCalledWith(['/docs']);
+  });
+
+  it('downloads file on desktop double click', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(<FolderContent />);
+
+    await user.dblClick(getByRole('button', { name: 'report.pdf' }));
+
+    expect(h.mockHandleBulkDownload).toHaveBeenCalledWith(['/report.pdf']);
+  });
+
+  it('opens folder path on mobile single tap', async () => {
+    setMobileLayout(true);
+    const user = userEvent.setup();
+    const { getByRole } = render(<FolderContent />);
+
+    await user.click(getByRole('button', { name: 'docs' }));
+
+    expect(h.mockSetPath).toHaveBeenCalledWith('/docs', h.selectedSpace);
+  });
+
+  it('selects file on mobile single tap without downloading', async () => {
+    setMobileLayout(true);
+    const user = userEvent.setup();
+    const { getByRole } = render(<FolderContent />);
+
+    await user.click(getByRole('button', { name: 'report.pdf' }));
+
+    expect(h.mockSetSelection).toHaveBeenCalledWith(new Set(['/report.pdf']), 1);
+    expect(h.mockHandleBulkDownload).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-download on single click in touch-capable desktop layout', async () => {
+    setTouchSupport(true);
+    const user = userEvent.setup();
+    const { getByRole } = render(<FolderContent />);
+
+    await user.click(getByRole('button', { name: 'report.pdf' }));
+
+    expect(h.mockHandleItemClick).toHaveBeenCalledTimes(1);
+    expect(h.mockHandleBulkDownload).not.toHaveBeenCalled();
+  });
+
+  it('downloads file on touch double tap in touch-capable desktop layout', () => {
+    setTouchSupport(true);
+    const { getByRole } = render(<FolderContent />);
+    const item = getByRole('button', { name: 'report.pdf' });
+
+    dispatchTouchEvent(item, 'touchstart', [{ clientX: 20, clientY: 30 }]);
+    dispatchTouchEvent(item, 'touchend', []);
+    item.click();
+
+    dispatchTouchEvent(item, 'touchstart', [{ clientX: 20, clientY: 30 }]);
+    dispatchTouchEvent(item, 'touchend', []);
+    item.click();
+
+    expect(h.mockHandleBulkDownload).toHaveBeenCalledTimes(1);
+    expect(h.mockHandleBulkDownload).toHaveBeenCalledWith(['/report.pdf']);
+  });
+
+  it('opens folder path on touch double tap in touch-capable desktop layout', () => {
+    setTouchSupport(true);
+    const { getByRole } = render(<FolderContent />);
+    const item = getByRole('button', { name: 'docs' });
+
+    dispatchTouchEvent(item, 'touchstart', [{ clientX: 18, clientY: 26 }]);
+    dispatchTouchEvent(item, 'touchend', []);
+    item.click();
+
+    dispatchTouchEvent(item, 'touchstart', [{ clientX: 18, clientY: 26 }]);
+    dispatchTouchEvent(item, 'touchend', []);
+    item.click();
+
+    expect(h.mockSetPath).toHaveBeenCalledTimes(1);
+    expect(h.mockSetPath).toHaveBeenCalledWith('/docs', h.selectedSpace);
+  });
+
+  it('does not duplicate activation when native double click follows touch fallback', () => {
+    setTouchSupport(true);
+    const { getByRole } = render(<FolderContent />);
+    const item = getByRole('button', { name: 'report.pdf' });
+
+    dispatchTouchEvent(item, 'touchstart', [{ clientX: 20, clientY: 30 }]);
+    dispatchTouchEvent(item, 'touchend', []);
+    item.click();
+
+    dispatchTouchEvent(item, 'touchstart', [{ clientX: 20, clientY: 30 }]);
+    dispatchTouchEvent(item, 'touchend', []);
+    item.click();
+
+    item.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    expect(h.mockHandleBulkDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps long-press selection precedence in mobile layout', () => {
+    setMobileLayout(true);
+    vi.useFakeTimers();
+    try {
+      const { getByRole } = render(<FolderContent />);
+      const item = getByRole('button', { name: 'report.pdf' });
+
+      dispatchTouchEvent(item, 'touchstart', [{ clientX: 20, clientY: 30 }]);
+      vi.advanceTimersByTime(420);
+      dispatchTouchEvent(item, 'touchend', []);
+      item.click();
+
+      expect(h.mockSetSelection).toHaveBeenCalledWith(new Set(['/report.pdf']));
+      expect(h.mockHandleBulkDownload).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps search mode activation routed to search result handler', async () => {
+    h.locationPathState.pathname = '/search';
+    const user = userEvent.setup();
+    const { getByRole } = render(<FolderContent />);
+
+    await user.click(getByRole('button', { name: 'report.pdf' }));
+
+    expect(h.mockOpenSearchResult).toHaveBeenCalledWith('/report.pdf');
+    expect(h.mockHandleBulkDownload).not.toHaveBeenCalled();
+    expect(h.mockSetPath).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/features/browse/components/FolderContent.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent.tsx
@@ -30,24 +30,14 @@ import { useTranslation } from 'react-i18next';
 
 const LONG_PRESS_DURATION_MS = 420;
 const TOUCH_PAN_THRESHOLD_PX = 8;
+const DESKTOP_TOUCH_DOUBLE_TAP_WINDOW_MS = 320;
+const DESKTOP_TOUCH_DOUBLE_CLICK_GUARD_MS = 480;
+const DESKTOP_TOUCH_EVENT_WINDOW_MS = 700;
 const PATH_BAR_HEIGHT = 36;
 const EXPLORER_SIDE_PADDING = 16;
 const PATH_BAR_CONTENT_OVERLAY_HEIGHT = PATH_BAR_HEIGHT - EXPLORER_SIDE_PADDING;
 type BrowseLocationState = { fromSearchQuery?: string };
 const EMPTY_SELECTION = new Set<string>();
-
-function detectTouchInputSupport(): boolean {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-    return false;
-  }
-
-  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
-  const hasCoarsePointer =
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(any-pointer: coarse)').matches;
-
-  return maxTouchPoints > 0 || hasCoarsePointer;
-}
 
 const FolderContent: React.FC = () => {
   const { t } = useTranslation();
@@ -95,16 +85,18 @@ const FolderContent: React.FC = () => {
   const [isMobileActionsOpen, setIsMobileActionsOpen] = useState(false);
   const [isPathOverflow, setIsPathOverflow] = useState(false);
   const [overlayOffset, setOverlayOffset] = useState({ x: 0, y: 0 });
-  const [hasTouchInput, setHasTouchInput] = useState<boolean>(() => detectTouchInputSupport());
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastLongPressRef = useRef<{ path: string; expiresAt: number } | null>(null);
+  const desktopTouchTapRef = useRef<{ path: string; at: number } | null>(null);
+  const desktopTouchDoubleClickGuardRef = useRef<{ path: string; expiresAt: number } | null>(null);
+  const recentDesktopTouchRef = useRef(0);
   const suppressTapUntilRef = useRef(0);
   const touchStartPointRef = useRef<{ x: number; y: number } | null>(null);
   const isTouchPanningRef = useRef(false);
   const selectedItemsRef = useRef<Set<string>>(new Set());
-  const interactionMode = hasTouchInput ? 'touch' : 'pointer';
   const isMobileLayout = layoutMode === 'mobile';
-  const isTouchInteraction = interactionMode === 'touch';
+  const isTouchInteraction = isMobileLayout;
+  const isDesktopTouchFallbackEnabled = !isTouchInteraction && typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0;
 
   // Modal management
   const { modals, openModal, closeModal, updateModalData } = useModalManager();
@@ -132,6 +124,10 @@ const FolderContent: React.FC = () => {
       clearTimeout(longPressTimerRef.current);
       longPressTimerRef.current = null;
     }
+  }, []);
+
+  const clearDesktopTouchTapState = useCallback(() => {
+    desktopTouchTapRef.current = null;
   }, []);
 
   const handleClearSelection = useCallback(() => {
@@ -215,6 +211,14 @@ const FolderContent: React.FC = () => {
 
   // 정렬된 콘텐츠 (폴더 우선 + sortConfig)
   const sortedContent = useSortedContent(sourceContent, sortConfig);
+
+  const contentByPath = useMemo(() => {
+    const next = new Map<string, FileNode>();
+    sortedContent.forEach((item) => {
+      next.set(item.path, item);
+    });
+    return next;
+  }, [sortedContent]);
   const effectiveViewMode: ViewMode = viewMode;
 
   const { handleContextMenu, handleEmptyAreaContextMenu } = useContextMenu({
@@ -340,36 +344,9 @@ const FolderContent: React.FC = () => {
   useEffect(() => {
     return () => {
       clearLongPressTimer();
+      clearDesktopTouchTapState();
     };
-  }, [clearLongPressTimer]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return;
-    }
-
-    const media = window.matchMedia('(any-pointer: coarse)');
-    const updateTouchCapability = () => {
-      const maxTouchPoints = typeof navigator !== 'undefined' ? (navigator.maxTouchPoints ?? 0) : 0;
-      setHasTouchInput(maxTouchPoints > 0 || media.matches);
-    };
-
-    updateTouchCapability();
-
-    if (typeof media.addEventListener === 'function') {
-      media.addEventListener('change', updateTouchCapability);
-      return () => {
-        media.removeEventListener('change', updateTouchCapability);
-      };
-    }
-
-    if (typeof media.addListener === 'function') {
-      media.addListener(updateTouchCapability);
-      return () => {
-        media.removeListener(updateTouchCapability);
-      };
-    }
-  }, []);
+  }, [clearDesktopTouchTapState, clearLongPressTimer]);
 
   useLayoutEffect(() => {
     const viewport = pathBarViewportRef.current;
@@ -496,6 +473,7 @@ const FolderContent: React.FC = () => {
     }
     clearLongPressTimer();
     longPressTimerRef.current = setTimeout(() => {
+      clearDesktopTouchTapState();
       lastLongPressRef.current = {
         path: record.path,
         expiresAt: Date.now() + 900,
@@ -503,26 +481,29 @@ const FolderContent: React.FC = () => {
       setIsMobileSelectionMode(true);
       setSelection(new Set([record.path]));
     }, LONG_PRESS_DURATION_MS);
-  }, [isMobileSelectionMode, isSearchMode, isTouchInteraction, clearLongPressTimer, setSelection]);
+  }, [isMobileSelectionMode, isSearchMode, isTouchInteraction, clearLongPressTimer, clearDesktopTouchTapState, setSelection]);
 
-  const handleMobileLongPressEnd = useCallback(() => {
+  const handleTouchInteractionEnd = useCallback(() => {
     clearLongPressTimer();
   }, [clearLongPressTimer]);
 
   const handleSelectionTouchStartCapture = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
-    if (!isTouchInteraction) {
+    if (!isTouchInteraction && !isDesktopTouchFallbackEnabled) {
       return;
     }
     const touch = event.touches[0];
     if (!touch) {
       return;
     }
+    if (isDesktopTouchFallbackEnabled) {
+      recentDesktopTouchRef.current = Date.now();
+    }
     touchStartPointRef.current = { x: touch.clientX, y: touch.clientY };
     isTouchPanningRef.current = false;
-  }, [isTouchInteraction]);
+  }, [isDesktopTouchFallbackEnabled, isTouchInteraction]);
 
   const handleSelectionTouchMoveCapture = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
-    if (!isTouchInteraction) {
+    if (!isTouchInteraction && !isDesktopTouchFallbackEnabled) {
       return;
     }
     const touch = event.touches[0];
@@ -535,40 +516,98 @@ const FolderContent: React.FC = () => {
     if (deltaX > TOUCH_PAN_THRESHOLD_PX || deltaY > TOUCH_PAN_THRESHOLD_PX) {
       isTouchPanningRef.current = true;
       clearLongPressTimer();
+      clearDesktopTouchTapState();
     }
-  }, [isTouchInteraction, clearLongPressTimer]);
+  }, [isDesktopTouchFallbackEnabled, isTouchInteraction, clearDesktopTouchTapState, clearLongPressTimer]);
 
   const handleSelectionTouchEndCapture = useCallback(() => {
-    if (!isTouchInteraction) {
+    if (!isTouchInteraction && !isDesktopTouchFallbackEnabled) {
       return;
     }
     clearLongPressTimer();
     if (isTouchPanningRef.current) {
       suppressTapUntilRef.current = Math.max(suppressTapUntilRef.current, Date.now() + 250);
+      clearDesktopTouchTapState();
     }
     isTouchPanningRef.current = false;
     touchStartPointRef.current = null;
-  }, [isTouchInteraction, clearLongPressTimer]);
+  }, [isDesktopTouchFallbackEnabled, isTouchInteraction, clearDesktopTouchTapState, clearLongPressTimer]);
+
+  const handleItemActivate = useCallback((path: string) => {
+    const record = contentByPath.get(path);
+    if (!record) {
+      return;
+    }
+
+    if (record.isDir) {
+      handleNavigate(path);
+      return;
+    }
+
+    void handleBulkDownload([record.path]);
+  }, [contentByPath, handleBulkDownload, handleNavigate]);
+
+  const handleItemDoubleClick = useCallback((path: string) => {
+    const guard = desktopTouchDoubleClickGuardRef.current;
+    if (guard?.path === path) {
+      if (Date.now() <= guard.expiresAt) {
+        return;
+      }
+      desktopTouchDoubleClickGuardRef.current = null;
+    }
+
+    handleItemActivate(path);
+  }, [handleItemActivate]);
 
   const handleItemTap = useCallback((e: React.MouseEvent<HTMLElement>, record: FileNode, index: number) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-item-action="true"]')) {
+      clearDesktopTouchTapState();
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
     if (Date.now() < suppressTapUntilRef.current) {
+      clearDesktopTouchTapState();
       e.preventDefault();
       e.stopPropagation();
       return;
     }
 
     if (isAnyModalOpen) {
+      clearDesktopTouchTapState();
       e.preventDefault();
       e.stopPropagation();
       return;
     }
 
     if (isSearchMode) {
+      clearDesktopTouchTapState();
       openSearchResultByRecordPath(record.path);
       return;
     }
 
     if (!isTouchInteraction) {
+      const isDesktopTouchEvent = isDesktopTouchFallbackEnabled
+        && (Date.now() - recentDesktopTouchRef.current <= DESKTOP_TOUCH_EVENT_WINDOW_MS);
+      const hasModifier = e.altKey || e.ctrlKey || e.metaKey || e.shiftKey;
+      if (isDesktopTouchEvent && !hasModifier) {
+        const now = Date.now();
+        const lastTap = desktopTouchTapRef.current;
+        if (lastTap && lastTap.path === record.path && (now - lastTap.at) <= DESKTOP_TOUCH_DOUBLE_TAP_WINDOW_MS) {
+          clearDesktopTouchTapState();
+          desktopTouchDoubleClickGuardRef.current = {
+            path: record.path,
+            expiresAt: now + DESKTOP_TOUCH_DOUBLE_CLICK_GUARD_MS,
+          };
+          handleItemActivate(record.path);
+          return;
+        }
+        desktopTouchTapRef.current = { path: record.path, at: now };
+      } else {
+        clearDesktopTouchTapState();
+      }
       handleItemClick(e, record, index, sortedContent);
       return;
     }
@@ -586,24 +625,34 @@ const FolderContent: React.FC = () => {
     }
 
     if (isMobileSelectionMode) {
+      clearDesktopTouchTapState();
       toggleMobileSelection(record.path);
       return;
     }
 
     if (record.isDir) {
+      clearDesktopTouchTapState();
       handleNavigate(record.path);
       handleClearSelection();
       return;
     }
+
+    clearDesktopTouchTapState();
+    setSelection(new Set([record.path]), index);
+    setIsMobileActionsOpen(false);
   }, [
+    clearDesktopTouchTapState,
     isAnyModalOpen,
+    isDesktopTouchFallbackEnabled,
     isTouchInteraction,
     isMobileSelectionMode,
     isSearchMode,
+    handleItemActivate,
     handleClearSelection,
     handleItemClick,
     handleNavigate,
     openSearchResultByRecordPath,
+    setSelection,
     sortedContent,
     toggleMobileSelection,
   ]);
@@ -953,11 +1002,11 @@ const FolderContent: React.FC = () => {
 
       <div
         ref={selectionContainerRef}
-        onScroll={isTouchInteraction ? handleMobileLongPressEnd : undefined}
-        onTouchStartCapture={isTouchInteraction ? handleSelectionTouchStartCapture : undefined}
-        onTouchMoveCapture={isTouchInteraction ? handleSelectionTouchMoveCapture : undefined}
-        onTouchEndCapture={isTouchInteraction ? handleSelectionTouchEndCapture : undefined}
-        onTouchCancelCapture={isTouchInteraction ? handleSelectionTouchEndCapture : undefined}
+        onScroll={isTouchInteraction || isDesktopTouchFallbackEnabled ? handleTouchInteractionEnd : undefined}
+        onTouchStartCapture={isTouchInteraction || isDesktopTouchFallbackEnabled ? handleSelectionTouchStartCapture : undefined}
+        onTouchMoveCapture={isTouchInteraction || isDesktopTouchFallbackEnabled ? handleSelectionTouchMoveCapture : undefined}
+        onTouchEndCapture={isTouchInteraction || isDesktopTouchFallbackEnabled ? handleSelectionTouchEndCapture : undefined}
+        onTouchCancelCapture={isTouchInteraction || isDesktopTouchFallbackEnabled ? handleSelectionTouchEndCapture : undefined}
         style={{
           position: 'relative',
           flex: 1,
@@ -1016,10 +1065,10 @@ const FolderContent: React.FC = () => {
                 selectedItems={isSearchMode ? EMPTY_SELECTION : selectedItems}
                 dragOverFolder={isSearchMode ? null : dragOverFolder}
                 onItemClick={handleItemTap}
-                onItemDoubleClick={isSearchMode ? openSearchResultByRecordPath : handleNavigate}
+                onItemDoubleClick={isSearchMode ? openSearchResultByRecordPath : handleItemDoubleClick}
                 onItemTouchStart={(record) => handleMobileLongPressStart(record)}
-                onItemTouchEnd={handleMobileLongPressEnd}
-                onItemTouchCancel={handleMobileLongPressEnd}
+                onItemTouchEnd={handleTouchInteractionEnd}
+                onItemTouchCancel={handleTouchInteractionEnd}
                 onContextMenu={handleItemContextMenu}
                 onItemDragStart={handleItemDragStart}
                 onItemDragEnd={handleItemDragEnd}
@@ -1046,10 +1095,10 @@ const FolderContent: React.FC = () => {
                 selectedItems={isSearchMode ? EMPTY_SELECTION : selectedItems}
                 dragOverFolder={isSearchMode ? null : dragOverFolder}
                 onItemClick={handleItemTap}
-                onItemDoubleClick={isSearchMode ? openSearchResultByRecordPath : handleNavigate}
+                onItemDoubleClick={isSearchMode ? openSearchResultByRecordPath : handleItemDoubleClick}
                 onItemTouchStart={(record) => handleMobileLongPressStart(record)}
-                onItemTouchEnd={handleMobileLongPressEnd}
-                onItemTouchCancel={handleMobileLongPressEnd}
+                onItemTouchEnd={handleTouchInteractionEnd}
+                onItemTouchCancel={handleTouchInteractionEnd}
                 onContextMenu={handleItemContextMenu}
                 onItemDragStart={handleItemDragStart}
                 onItemDragEnd={handleItemDragEnd}

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.test.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { FileNode } from '../../types';
+import FolderContentGrid from './FolderContentGrid';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const noop = vi.fn();
+
+function buildRecord(overrides: Partial<FileNode>): FileNode {
+  return {
+    name: 'item',
+    path: '/item',
+    isDir: false,
+    modTime: '2026-03-01T00:00:00.000Z',
+    size: 128,
+    ...overrides,
+  };
+}
+
+function renderGrid(dataSource: FileNode[], onItemDoubleClick: (path: string) => void) {
+  return render(
+    <FolderContentGrid
+      dataSource={dataSource}
+      loading={false}
+      selectedItems={new Set()}
+      dragOverFolder={null}
+      onItemClick={noop}
+      onItemDoubleClick={onItemDoubleClick}
+      onContextMenu={noop}
+      onItemDragStart={noop}
+      onItemDragEnd={noop}
+      onFolderDragOver={noop}
+      onFolderDragLeave={noop}
+      onFolderDrop={noop}
+      disableDraggable={true}
+    />
+  );
+}
+
+describe('FolderContentGrid', () => {
+  it('calls onItemDoubleClick for file cards', async () => {
+    const user = userEvent.setup();
+    const onItemDoubleClick = vi.fn();
+    const file = buildRecord({ name: 'draft.md', path: '/draft.md', isDir: false });
+
+    const { getByText } = renderGrid([file], onItemDoubleClick);
+    await user.dblClick(getByText('draft.md'));
+
+    expect(onItemDoubleClick).toHaveBeenCalledWith('/draft.md');
+  });
+
+  it('keeps folder double click callback behavior', async () => {
+    const user = userEvent.setup();
+    const onItemDoubleClick = vi.fn();
+    const folder = buildRecord({ name: 'archive', path: '/archive', isDir: true, size: 0 });
+
+    const { getByText } = renderGrid([folder], onItemDoubleClick);
+    await user.dblClick(getByText('archive'));
+
+    expect(onItemDoubleClick).toHaveBeenCalledWith('/archive');
+  });
+});

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx
@@ -84,7 +84,7 @@ const FolderContentGrid: React.FC<FolderContentGridProps> = ({
                 hoverable
                 draggable={!disableDraggable}
                 onClick={(e) => onItemClick(e, item, index)}
-                onDoubleClick={() => item.isDir && onItemDoubleClick(item.path)}
+                onDoubleClick={() => onItemDoubleClick(item.path)}
                 onTouchStart={() => onItemTouchStart?.(item, index)}
                 onTouchEnd={() => onItemTouchEnd?.()}
                 onTouchCancel={() => onItemTouchCancel?.()}

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.test.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.test.tsx
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { FileNode } from '../../types';
+import FolderContentTable from './FolderContentTable';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const noop = vi.fn();
+
+function buildRecord(overrides: Partial<FileNode>): FileNode {
+  return {
+    name: 'item',
+    path: '/item',
+    isDir: false,
+    modTime: '2026-03-01T00:00:00.000Z',
+    size: 128,
+    ...overrides,
+  };
+}
+
+function renderTable(
+  dataSource: FileNode[],
+  onItemDoubleClick: (path: string) => void,
+  showActions = false
+) {
+  return render(
+    <FolderContentTable
+      dataSource={dataSource}
+      loading={false}
+      selectedItems={new Set()}
+      dragOverFolder={null}
+      onItemClick={noop}
+      onItemDoubleClick={onItemDoubleClick}
+      onContextMenu={noop}
+      onItemDragStart={noop}
+      onItemDragEnd={noop}
+      onFolderDragOver={noop}
+      onFolderDragLeave={noop}
+      onFolderDrop={noop}
+      canWriteFiles={true}
+      showActions={showActions}
+    />
+  );
+}
+
+describe('FolderContentTable', () => {
+  it('calls onItemDoubleClick for file rows', async () => {
+    const user = userEvent.setup();
+    const onItemDoubleClick = vi.fn();
+    const file = buildRecord({ name: 'notes.txt', path: '/notes.txt', isDir: false });
+
+    const { getByText } = renderTable([file], onItemDoubleClick);
+    await user.dblClick(getByText('notes.txt'));
+
+    expect(onItemDoubleClick).toHaveBeenCalledWith('/notes.txt');
+  });
+
+  it('keeps folder double click navigation callback behavior', async () => {
+    const user = userEvent.setup();
+    const onItemDoubleClick = vi.fn();
+    const folder = buildRecord({ name: 'docs', path: '/docs', isDir: true, size: 0 });
+
+    const { getByText } = renderTable([folder], onItemDoubleClick);
+    await user.dblClick(getByText('docs'));
+
+    expect(onItemDoubleClick).toHaveBeenCalledWith('/docs');
+  });
+
+  it('does not trigger row activation when double-clicking action button', async () => {
+    const user = userEvent.setup();
+    const onItemDoubleClick = vi.fn();
+    const file = buildRecord({ name: 'notes.txt', path: '/notes.txt', isDir: false });
+
+    const { getByLabelText } = renderTable([file], onItemDoubleClick, true);
+    await user.dblClick(getByLabelText('browseMenu.more'));
+
+    expect(onItemDoubleClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx
@@ -152,7 +152,9 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
                   type="text"
                   size="small"
                   icon={<MoreOutlined />}
+                  data-item-action="true"
                   onClick={(e) => e.stopPropagation()}
+                  onDoubleClick={(e) => e.stopPropagation()}
                   aria-label={t('browseMenu.more')}
                   title={t('browseMenu.more')}
                 />
@@ -184,7 +186,7 @@ const FolderContentTable: React.FC<FolderContentTableProps> = ({
       }}
       onRow={(record: FileNode, index?: number) => ({
         onClick: (e: React.MouseEvent<HTMLElement>) => onItemClick(e, record, index ?? 0),
-        onDoubleClick: () => record.isDir && onItemDoubleClick(record.path),
+        onDoubleClick: () => onItemDoubleClick(record.path),
         onTouchStart: () => onItemTouchStart?.(record, index ?? 0),
         onTouchEnd: () => onItemTouchEnd?.(),
         onTouchCancel: () => onItemTouchCancel?.(),

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -1,0 +1,31 @@
+import { afterEach, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+if (!globalThis.ResizeObserver) {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  globalThis.ResizeObserver = ResizeObserverMock;
+}

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    css: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
@@ -84,6 +90,9 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -93,8 +102,14 @@ importers:
       vite:
         specifier: ^7.2.6
         version: 7.2.6(@types/node@24.10.1)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@24.10.1)(jsdom@28.1.0)
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
   '@ant-design/colors@8.0.0':
     resolution: {integrity: sha512-6YzkKCw30EI/E9kHOIXsQDHmMvTllT8STzjMb4K2qzit33RW2pqCJP0sk+hidBntXxE+Vz4n1+RvCTfBw6OErw==}
@@ -129,6 +144,16 @@ packages:
     resolution: {integrity: sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==}
     peerDependencies:
       react: '>=16.9.0'
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -200,6 +225,41 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.28':
+    resolution: {integrity: sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emotion/hash@0.8.0':
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
@@ -400,6 +460,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -824,6 +893,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/core-darwin-arm64@1.15.3':
     resolution: {integrity: sha512-AXfeQn0CvcQ4cndlIshETx6jrAM45oeUrK8YeEY6oUZU/qzz0Id0CyvlEywxkWVC81Ajpd8TQQ1fW5yx6zQWkQ==}
     engines: {node: '>=10'}
@@ -898,6 +970,40 @@ packages:
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -981,6 +1087,35 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7
 
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -991,12 +1126,24 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   antd@6.0.1:
     resolution: {integrity: sha512-/kCH3057suoqe1D/JJ4lxvkESZWJr1+ISTbRnbxk99gXJWaxYp7pCX+4CZSdvVDKFpU1YBkzHn9/ZVNNyHImqQ==}
@@ -1007,6 +1154,13 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1014,6 +1168,9 @@ packages:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1032,6 +1189,10 @@ packages:
 
   caniuse-lite@1.0.30001757:
     resolution: {integrity: sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1068,8 +1229,20 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@6.1.0:
+    resolution: {integrity: sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==}
+    engines: {node: '>=20'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
@@ -1083,11 +1256,28 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   electron-to-chromium@1.5.263:
     resolution: {integrity: sha512-DrqJ11Knd+lo+dv+lltvfMDLU27g14LMdH2b0O3Pio4uk0x+z7OR+JrmyacTPN2M8w3BrZ7/RTwG3R9B7irPlg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1151,9 +1341,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1233,8 +1430,20 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   i18next@25.8.13:
     resolution: {integrity: sha512-E0vzjBY1yM+nsFrtgkjLhST2NBkirkvOVoQa0MSldhsuZ3jUge7ZNpuwG0Cfc74zwo5ZwRzg3uOgT+McBn32iA==}
@@ -1271,6 +1480,9 @@ packages:
   is-mobile@5.0.0:
     resolution: {integrity: sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1280,6 +1492,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1324,8 +1545,22 @@ packages:
     resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
@@ -1356,6 +1591,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1375,6 +1613,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1386,6 +1627,9 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1401,6 +1645,10 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1457,6 +1705,9 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -1472,6 +1723,10 @@ packages:
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resize-observer-polyfill@1.5.1:
@@ -1490,6 +1745,10 @@ packages:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1517,9 +1776,18 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
@@ -1535,13 +1803,42 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
     engines: {node: '>=12.22'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.23:
+    resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
+
+  tldts@7.0.23:
+    resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
+    hasBin: true
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -1602,6 +1899,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -1660,18 +1961,80 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1708,6 +2071,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
 
   '@ant-design/colors@8.0.0':
     dependencies:
@@ -1754,6 +2119,24 @@ snapshots:
       react: 19.2.0
       resize-observer-polyfill: 1.5.1
       throttle-debounce: 5.0.2
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -1856,6 +2239,32 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.1.0
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emotion/hash@0.8.0': {}
 
@@ -1984,6 +2393,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.14.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -2417,6 +2828,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/core-darwin-arm64@1.15.3':
     optional: true
 
@@ -2468,6 +2881,40 @@ snapshots:
   '@swc/types@0.1.25':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2585,11 +3032,52 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.2.6(@types/node@24.10.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.6(@types/node@24.10.1)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -2598,9 +3086,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   antd@6.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -2661,9 +3153,19 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.0: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -2685,6 +3187,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001757: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2715,7 +3219,26 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  cssstyle@6.1.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.28
+      css-tree: 3.1.0
+      lru-cache: 11.2.6
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   dayjs@1.11.19: {}
 
@@ -2723,9 +3246,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
+  dequal@2.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
   electron-to-chromium@1.5.263: {}
+
+  entities@6.0.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2839,7 +3372,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2904,9 +3443,29 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   i18next@25.8.13(typescript@5.9.3):
     dependencies:
@@ -2933,6 +3492,8 @@ snapshots:
 
   is-mobile@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -2940,6 +3501,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@28.1.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.14.1
+      cssstyle: 6.1.0
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      undici: 7.22.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   jsesc@3.1.0: {}
 
@@ -2978,9 +3566,19 @@ snapshots:
 
   lru-cache@11.2.4: {}
 
+  lru-cache@11.2.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.12.2: {}
 
   minimatch@10.1.1:
     dependencies:
@@ -3003,6 +3601,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.27: {}
+
+  obug@2.1.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -3027,6 +3627,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3035,6 +3639,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.4
       minipass: 7.1.2
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3047,6 +3653,12 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   punycode@2.3.1: {}
 
@@ -3104,6 +3716,8 @@ snapshots:
     dependencies:
       react: 19.2.0
 
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   react-router@7.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
@@ -3115,6 +3729,8 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
 
   react@19.2.0: {}
+
+  require-from-string@2.0.2: {}
 
   resize-observer-polyfill@1.5.1: {}
 
@@ -3153,6 +3769,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   scroll-into-view-if-needed@3.1.0:
@@ -3171,7 +3791,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-convert@0.2.1: {}
 
@@ -3183,12 +3809,34 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   throttle-debounce@5.0.2: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
+  tldts-core@7.0.23: {}
+
+  tldts@7.0.23:
+    dependencies:
+      tldts-core: 7.0.23
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.23
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -3240,6 +3888,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@7.22.0: {}
+
   universalify@2.0.1: {}
 
   update-browserslist-db@1.1.4(browserslist@4.28.0):
@@ -3268,13 +3918,76 @@ snapshots:
       '@types/node': 24.10.1
       fsevents: 2.3.3
 
+  vitest@4.0.18(@types/node@24.10.1)(jsdom@28.1.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.2.6(@types/node@24.10.1))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.6(@types/node@24.10.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.1
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   void-elements@3.1.0: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## 요약
- 파일/폴더 활성화 정책을 레이아웃 기준으로 안정화했습니다.
- 데스크톱+터치 환경에서 native `dblclick` 누락 시에도 더블탭으로 활성화되도록 fallback을 추가했습니다.
- 모바일은 파일 단일탭 시 즉시 다운로드하지 않고 단일 선택으로 동작하도록 조정했습니다.
- 테이블/그리드 액션 버튼 더블클릭 전파 차단을 보강했습니다.
- 파일 활성화 회귀 테스트(Vitest) 세트를 추가했습니다.

## 변경 파일
- `apps/frontend/src/features/browse/components/FolderContent.tsx`
- `apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.tsx`
- `apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.tsx`
- `apps/frontend/src/features/browse/components/FolderContent.test.tsx`
- `apps/frontend/src/features/browse/components/FolderContent/FolderContentTable.test.tsx`
- `apps/frontend/src/features/browse/components/FolderContent/FolderContentGrid.test.tsx`
- `apps/frontend/src/test/setup.ts`
- `apps/frontend/vitest.config.ts`
- `apps/frontend/package.json`
- `pnpm-lock.yaml`

## 검증
- `pnpm -C apps/frontend lint`
- `pnpm -C apps/frontend typecheck`
- `pnpm -C apps/frontend test`
- `pnpm -C apps/frontend build`

## 이슈 상태 확인
- `lteawoo/Cohesion` 기준 열린 이슈 중 파일 활성화/제스처 관련 이슈는 확인되지 않았습니다.
