### PR TITLE
fix: 운영 로그 표준화와 fallback 로깅 보강

### DIFF
--- a/apps/backend/cmd/updater/main.go
+++ b/apps/backend/cmd/updater/main.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog"
+	"taeu.kr/cohesion/internal/platform/logging"
 )
 
 type updaterArgs struct {
@@ -20,14 +23,6 @@ type updaterArgs struct {
 	workdir     string
 	argsFile    string
 	cleanupDir  string
-}
-
-type updaterLogger struct {
-	out io.Writer
-}
-
-func (l updaterLogger) logf(format string, args ...any) {
-	_, _ = fmt.Fprintf(l.out, "[updater] %s\n", fmt.Sprintf(format, args...))
 }
 
 func openRootLogFile(targetPath, fileName string) (*os.File, string, error) {
@@ -48,27 +43,47 @@ func openRootLogFile(targetPath, fileName string) (*os.File, string, error) {
 func main() {
 	args, err := parseFlags()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[updater] invalid arguments: %v\n", err)
+		fmt.Fprintf(os.Stderr, "%s ERROR [updater] fatal.updater.invalid_args - invalid updater arguments err=%q\n", time.Now().UTC().Format(time.RFC3339), err.Error())
 		os.Exit(2)
 	}
 
-	logger := updaterLogger{out: os.Stderr}
+	logger := newUpdaterLogger(logging.NewMirroredWriter(io.Discard, os.Stderr))
 	logFile, updaterLogPath, logErr := openRootLogFile(args.target, "updater.log")
 	if logErr != nil {
-		fmt.Fprintf(os.Stderr, "[updater] failed to initialize updater.log: %v\n", logErr)
+		logging.Event(logger.Error(), logging.ComponentUpdater, "error.updater.log_sink_init_failed").
+			Err(logErr).
+			Msg("failed to initialize updater log sink")
 	} else {
 		defer logFile.Close()
-		logger.out = io.MultiWriter(os.Stderr, logFile)
-		logger.logf("updater log initialized: %s", updaterLogPath)
+		logger = newUpdaterLogger(logging.NewMirroredWriter(logFile, os.Stderr))
+		logging.Event(logger.Info(), logging.ComponentUpdater, logging.EventServiceReady).
+			Str("service", "updater-log").
+			Str("path", updaterLogPath).
+			Msg("service log sink ready")
 	}
 
 	appLogPath := filepath.Join(filepath.Dir(args.target), "logs", "app.log")
-	logger.logf("starting update flow (pid=%d, target=%s, replacement=%s)", args.pid, args.target, args.replacement)
+	logging.Event(logger.Info(), logging.ComponentUpdater, logging.EventBootStart).
+		Int("pid", args.pid).
+		Str("target", args.target).
+		Str("replacement", args.replacement).
+		Msg("updater flow started")
 	if err := run(args, appLogPath, logger); err != nil {
-		logger.logf("failed: %v", err)
+		logging.Event(logger.Error(), logging.ComponentUpdater, "error.updater.run_failed").
+			Err(err).
+			Msg("updater flow failed")
 		os.Exit(1)
 	}
-	logger.logf("completed successfully")
+	logging.Event(logger.Info(), logging.ComponentUpdater, "updater.completed").
+		Msg("updater flow completed")
+}
+
+func newUpdaterLogger(out io.Writer) zerolog.Logger {
+	return zerolog.New(out).
+		With().
+		Timestamp().
+		Str(logging.FieldComponent, logging.ComponentUpdater).
+		Logger()
 }
 
 func parseFlags() (updaterArgs, error) {
@@ -105,7 +120,7 @@ func parseFlags() (updaterArgs, error) {
 	return parsed, nil
 }
 
-func run(args updaterArgs, appLogPath string, logger updaterLogger) error {
+func run(args updaterArgs, appLogPath string, logger zerolog.Logger) error {
 	if args.cleanupDir != "" {
 		defer os.RemoveAll(args.cleanupDir)
 	}
@@ -191,19 +206,25 @@ func rollbackBinary(targetPath, backupPath string) error {
 	return os.Rename(backupPath, targetPath)
 }
 
-func restartApplication(targetPath, workdir string, appArgs []string, appLogPath string, logger updaterLogger) error {
+func restartApplication(targetPath, workdir string, appArgs []string, appLogPath string, logger zerolog.Logger) error {
 	cmd := exec.Command(targetPath, appArgs...)
 	cmd.Dir = workdir
 	appLogFile, err := openAppLogFile(appLogPath)
 	if err != nil {
-		logger.logf("failed to open app log file (%s), fallback to stdio: %v", appLogPath, err)
+		logging.Event(logger.Warn(), logging.ComponentUpdater, "warn.updater.app_log_open_failed").
+			Str("path", appLogPath).
+			Err(err).
+			Msg("failed to open app log file, falling back to stdio")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	} else {
 		defer appLogFile.Close()
 		cmd.Stdout = appLogFile
 		cmd.Stderr = appLogFile
-		logger.logf("restarted app logs redirected to: %s", appLogPath)
+		logging.Event(logger.Info(), logging.ComponentUpdater, logging.EventServiceReady).
+			Str("service", "app-log-redirect").
+			Str("path", appLogPath).
+			Msg("service status updated")
 	}
 	cmd.Stdin = nil
 	cmd.Env = os.Environ()

--- a/apps/backend/cmd/updater/main_test.go
+++ b/apps/backend/cmd/updater/main_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"taeu.kr/cohesion/internal/platform/logging"
+)
+
+func TestNewUpdaterLogger_MirroredWriter(t *testing.T) {
+	var appBuffer bytes.Buffer
+	var terminalBuffer bytes.Buffer
+
+	logger := newUpdaterLogger(logging.NewMirroredWriter(&appBuffer, &terminalBuffer))
+	logging.Event(logger.Info(), logging.ComponentUpdater, logging.EventBootStart).
+		Int("pid", 1234).
+		Msg("updater flow started")
+
+	appLine := appBuffer.String()
+	if !strings.Contains(appLine, "event=boot.start") {
+		t.Fatalf("expected key=value event in updater file sink, got %q", appLine)
+	}
+	if !strings.Contains(appLine, "component=updater") {
+		t.Fatalf("expected component field in updater file sink, got %q", appLine)
+	}
+
+	terminalLine := terminalBuffer.String()
+	if !strings.Contains(terminalLine, "INFO [updater] boot.start - updater flow started") {
+		t.Fatalf("expected terminal pattern output, got %q", terminalLine)
+	}
+	if strings.Contains(terminalLine, "event=boot.start") {
+		t.Fatalf("expected pattern-style terminal output, got key=value output %q", terminalLine)
+	}
+}

--- a/apps/backend/internal/browse/service.go
+++ b/apps/backend/internal/browse/service.go
@@ -138,7 +138,7 @@ func NewService() *Service {
 		}
 		userHomeDir = filepath.Dir(executablePath)
 	} else {
-		log.Info().Msgf("초기 디렉토리: %s", userHomeDir)
+		log.Info().Str("home_path", userHomeDir).Msg("Initial home directory resolved")
 	}
 
 	// 디스크 파티션 정보 가져오기

--- a/apps/backend/internal/platform/logging/contract.go
+++ b/apps/backend/internal/platform/logging/contract.go
@@ -1,0 +1,82 @@
+package logging
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	FieldTimestamp = "ts"
+	FieldLevel     = "level"
+	FieldEvent     = "event"
+	FieldComponent = "component"
+	FieldMessage   = "msg"
+)
+
+const (
+	ComponentMain    = "main"
+	ComponentServer  = "server"
+	ComponentConfig  = "config"
+	ComponentDB      = "database"
+	ComponentRuntime = "runtime"
+	ComponentAuth    = "auth"
+	ComponentAccess  = "access"
+	ComponentUpdater = "updater"
+	ComponentStorage = "storage"
+)
+
+const (
+	EventBootStart            = "boot.start"
+	EventConfigLoaded         = "config.loaded"
+	EventDatabaseReady        = "db.ready"
+	EventServiceReady         = "service.ready"
+	EventServerReady          = "server.ready"
+	EventServerRestartRequest = "server.restart_requested"
+	EventServerRestarted      = "server.restart_completed"
+	EventServerShutdownSignal = "server.shutdown_signal"
+	EventServerShutdownDone   = "server.shutdown_completed"
+	EventHTTPAccess           = "http.access"
+)
+
+var terminalInfoEvents = map[string]struct{}{
+	EventBootStart:            {},
+	EventConfigLoaded:         {},
+	EventDatabaseReady:        {},
+	EventServiceReady:         {},
+	EventServerReady:          {},
+	EventServerRestartRequest: {},
+	EventServerRestarted:      {},
+	EventServerShutdownSignal: {},
+	EventServerShutdownDone:   {},
+}
+
+func TerminalInfoEventSet() map[string]struct{} {
+	copied := make(map[string]struct{}, len(terminalInfoEvents))
+	for eventName := range terminalInfoEvents {
+		copied[eventName] = struct{}{}
+	}
+	return copied
+}
+
+func Event(evt *zerolog.Event, component, eventName string) *zerolog.Event {
+	return evt.
+		Str(FieldComponent, normalizeComponent(component)).
+		Str(FieldEvent, normalizeEvent(eventName))
+}
+
+func normalizeComponent(component string) string {
+	component = strings.TrimSpace(component)
+	if component == "" {
+		return ComponentRuntime
+	}
+	return component
+}
+
+func normalizeEvent(eventName string) string {
+	eventName = strings.TrimSpace(eventName)
+	if eventName == "" {
+		return "runtime.log"
+	}
+	return eventName
+}

--- a/apps/backend/internal/platform/logging/writer.go
+++ b/apps/backend/internal/platform/logging/writer.go
@@ -1,0 +1,283 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type KeyValueWriter struct {
+	appWriter          io.Writer
+	terminalWriter     io.Writer
+	terminalInfoEvents map[string]struct{}
+	mirrorAllLevels    bool
+	mu                 sync.Mutex
+}
+
+func NewOperationalWriter(appWriter, terminalWriter io.Writer) io.Writer {
+	return &KeyValueWriter{
+		appWriter:          appWriter,
+		terminalWriter:     terminalWriter,
+		terminalInfoEvents: TerminalInfoEventSet(),
+	}
+}
+
+func NewMirroredWriter(appWriter, terminalWriter io.Writer) io.Writer {
+	return &KeyValueWriter{
+		appWriter:       appWriter,
+		terminalWriter:  terminalWriter,
+		mirrorAllLevels: true,
+	}
+}
+
+func NewKeyValueWriter(out io.Writer) io.Writer {
+	return &KeyValueWriter{
+		appWriter: out,
+	}
+}
+
+func (w *KeyValueWriter) Write(p []byte) (int, error) {
+	trimmed := bytes.TrimSpace(p)
+	if len(trimmed) == 0 {
+		return len(p), nil
+	}
+
+	record := make(map[string]any)
+	if err := json.Unmarshal(trimmed, &record); err != nil {
+		return w.writeRaw(trimmed, len(p))
+	}
+
+	line, level, eventName := buildKeyValueLine(record)
+	if len(line) == 0 {
+		return w.writeRaw(trimmed, len(p))
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, err := w.appWriter.Write(line); err != nil {
+		return 0, err
+	}
+
+	if w.shouldEmitTerminal(level, eventName) {
+		patternLine := buildTerminalPatternLine(record)
+		if len(patternLine) == 0 {
+			patternLine = line
+		}
+		if _, err := w.terminalWriter.Write(patternLine); err != nil {
+			return 0, err
+		}
+	}
+
+	return len(p), nil
+}
+
+func (w *KeyValueWriter) writeRaw(trimmed []byte, originalLength int) (int, error) {
+	line := append([]byte{}, trimmed...)
+	if len(line) == 0 || line[len(line)-1] != '\n' {
+		line = append(line, '\n')
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, err := w.appWriter.Write(line); err != nil {
+		return 0, err
+	}
+	if w.terminalWriter != nil {
+		if _, err := w.terminalWriter.Write(line); err != nil {
+			return 0, err
+		}
+	}
+
+	return originalLength, nil
+}
+
+func (w *KeyValueWriter) shouldEmitTerminal(level, eventName string) bool {
+	if w.terminalWriter == nil {
+		return false
+	}
+
+	if w.mirrorAllLevels {
+		return true
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(level)) {
+	case "WARN", "ERROR", "FATAL", "PANIC":
+		return true
+	case "INFO":
+		_, ok := w.terminalInfoEvents[eventName]
+		return ok
+	default:
+		return false
+	}
+}
+
+func buildTerminalPatternLine(record map[string]any) []byte {
+	ts := strings.TrimSpace(valueAsString(firstNonNil(record, FieldTimestamp, "time")))
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	level := strings.ToUpper(strings.TrimSpace(valueAsString(firstNonNil(record, FieldLevel))))
+	if level == "" {
+		level = "INFO"
+	}
+
+	eventName := normalizeEvent(valueAsString(firstNonNil(record, FieldEvent)))
+	component := normalizeComponent(valueAsString(firstNonNil(record, FieldComponent)))
+	message := strings.TrimSpace(valueAsString(firstNonNil(record, FieldMessage, "message")))
+	if message == "" {
+		message = "-"
+	}
+
+	excluded := map[string]struct{}{
+		FieldTimestamp: {},
+		"time":         {},
+		FieldLevel:     {},
+		FieldEvent:     {},
+		FieldComponent: {},
+		FieldMessage:   {},
+		"message":      {},
+	}
+
+	extraKeys := make([]string, 0, len(record))
+	for key := range record {
+		if _, ok := excluded[key]; ok {
+			continue
+		}
+		extraKeys = append(extraKeys, key)
+	}
+	sort.Strings(extraKeys)
+
+	extras := make([]string, 0, len(extraKeys))
+	for _, key := range extraKeys {
+		extras = append(extras, formatPair(key, valueAsString(record[key])))
+	}
+
+	line := fmt.Sprintf("%s %s [%s] %s - %s", ts, level, component, eventName, message)
+	if len(extras) > 0 {
+		line += " " + strings.Join(extras, " ")
+	}
+	return []byte(line + "\n")
+}
+
+func buildKeyValueLine(record map[string]any) ([]byte, string, string) {
+	ts := strings.TrimSpace(valueAsString(firstNonNil(record, FieldTimestamp, "time")))
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	level := strings.ToUpper(strings.TrimSpace(valueAsString(firstNonNil(record, FieldLevel))))
+	if level == "" {
+		level = "INFO"
+	}
+
+	eventName := normalizeEvent(valueAsString(firstNonNil(record, FieldEvent)))
+	component := normalizeComponent(valueAsString(firstNonNil(record, FieldComponent)))
+	message := strings.TrimSpace(valueAsString(firstNonNil(record, FieldMessage, "message")))
+
+	pairs := make([]string, 0, len(record)+5)
+	pairs = append(pairs, formatPair(FieldTimestamp, ts))
+	pairs = append(pairs, formatPair(FieldLevel, level))
+	pairs = append(pairs, formatPair(FieldEvent, eventName))
+	pairs = append(pairs, formatPair(FieldComponent, component))
+	pairs = append(pairs, formatPair(FieldMessage, message))
+
+	excluded := map[string]struct{}{
+		FieldTimestamp: {},
+		"time":         {},
+		FieldLevel:     {},
+		FieldEvent:     {},
+		FieldComponent: {},
+		FieldMessage:   {},
+		"message":      {},
+	}
+
+	extraKeys := make([]string, 0, len(record))
+	for key := range record {
+		if _, ok := excluded[key]; ok {
+			continue
+		}
+		extraKeys = append(extraKeys, key)
+	}
+	sort.Strings(extraKeys)
+
+	for _, key := range extraKeys {
+		pairs = append(pairs, formatPair(key, valueAsString(record[key])))
+	}
+
+	if len(pairs) == 0 {
+		return nil, level, eventName
+	}
+
+	return []byte(strings.Join(pairs, " ") + "\n"), level, eventName
+}
+
+func firstNonNil(record map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := record[key]; ok && value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func valueAsString(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case []byte:
+		return string(typed)
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	case json.Number:
+		return typed.String()
+	default:
+		switch number := typed.(type) {
+		case float64:
+			return strconv.FormatFloat(number, 'f', -1, 64)
+		case float32:
+			return strconv.FormatFloat(float64(number), 'f', -1, 32)
+		case int, int8, int16, int32, int64:
+			return fmt.Sprintf("%d", number)
+		case uint, uint8, uint16, uint32, uint64:
+			return fmt.Sprintf("%d", number)
+		}
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprint(typed)
+		}
+		return string(encoded)
+	}
+}
+
+func formatPair(key, value string) string {
+	if value == "" {
+		return key + "=\"\""
+	}
+	if needsQuotes(value) {
+		return key + "=" + strconv.Quote(value)
+	}
+	return key + "=" + value
+}
+
+func needsQuotes(value string) bool {
+	for _, r := range value {
+		if r == '"' || r == '=' || r == '\t' || r == '\n' || r == '\r' || r == ' ' {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/backend/internal/platform/logging/writer_test.go
+++ b/apps/backend/internal/platform/logging/writer_test.go
@@ -1,0 +1,124 @@
+package logging
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBuildTerminalPatternLine_OrderAndExtras(t *testing.T) {
+	record := map[string]any{
+		FieldTimestamp: "2026-03-03T01:30:21.123Z",
+		FieldLevel:     "info",
+		FieldComponent: "server",
+		FieldEvent:     "server.ready",
+		FieldMessage:   "server ready",
+		"port":         "3000",
+		"service":      "http",
+	}
+
+	got := string(buildTerminalPatternLine(record))
+	want := "2026-03-03T01:30:21.123Z INFO [server] server.ready - server ready port=3000 service=http\n"
+	if got != want {
+		t.Fatalf("unexpected terminal pattern line\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestBuildTerminalPatternLine_MissingFields(t *testing.T) {
+	record := map[string]any{
+		FieldTimestamp: "2026-03-03T01:30:21.123Z",
+		FieldLevel:     "warn",
+	}
+
+	got := string(buildTerminalPatternLine(record))
+	want := "2026-03-03T01:30:21.123Z WARN [runtime] runtime.log - -\n"
+	if got != want {
+		t.Fatalf("unexpected missing-field rendering\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestBuildTerminalPatternLine_DeterministicExtraFieldOrder(t *testing.T) {
+	record := map[string]any{
+		FieldTimestamp: "2026-03-03T01:30:21.123Z",
+		FieldLevel:     "error",
+		FieldComponent: "storage",
+		FieldEvent:     "warn.storage.cleanup_failed",
+		FieldMessage:   "cleanup failed",
+		"z":            "last",
+		"a":            "first",
+		"m":            "middle",
+	}
+
+	first := string(buildTerminalPatternLine(record))
+	for i := 0; i < 10; i++ {
+		got := string(buildTerminalPatternLine(record))
+		if got != first {
+			t.Fatalf("expected deterministic output; run %d mismatch\nfirst: %q\ngot:   %q", i, first, got)
+		}
+	}
+
+	wantSuffix := " a=first m=middle z=last\n"
+	if len(first) < len(wantSuffix) || first[len(first)-len(wantSuffix):] != wantSuffix {
+		t.Fatalf("unexpected extra-field order in %q", first)
+	}
+}
+
+func TestNewOperationalWriter_FileAndTerminalSplit(t *testing.T) {
+	var appBuf bytes.Buffer
+	var terminalBuf bytes.Buffer
+
+	writer := NewOperationalWriter(&appBuf, &terminalBuf)
+
+	input := []byte(`{"ts":"2026-03-03T01:30:21.123Z","level":"info","event":"server.ready","component":"server","msg":"server ready","port":"3000"}`)
+	if _, err := writer.Write(input); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	appLine := appBuf.String()
+	terminalLine := terminalBuf.String()
+
+	if appLine == "" || terminalLine == "" {
+		t.Fatalf("expected both app and terminal lines, got app=%q terminal=%q", appLine, terminalLine)
+	}
+	if appLine == terminalLine {
+		t.Fatalf("expected file and terminal lines to differ, both=%q", appLine)
+	}
+	if !bytes.Contains([]byte(appLine), []byte("event=server.ready")) {
+		t.Fatalf("expected key=value file line, got %q", appLine)
+	}
+	if !bytes.Contains([]byte(terminalLine), []byte("[server] server.ready - server ready")) {
+		t.Fatalf("expected pattern terminal line, got %q", terminalLine)
+	}
+}
+
+func TestNewOperationalWriter_TerminalInfoWhitelist(t *testing.T) {
+	var appBuf bytes.Buffer
+	var terminalBuf bytes.Buffer
+
+	writer := NewOperationalWriter(&appBuf, &terminalBuf)
+	input := []byte(`{"ts":"2026-03-03T01:30:21.123Z","level":"info","event":"custom.info","component":"main","msg":"custom info"}`)
+	if _, err := writer.Write(input); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if appBuf.Len() == 0 {
+		t.Fatal("expected app log line")
+	}
+	if terminalBuf.Len() != 0 {
+		t.Fatalf("expected no terminal info line for non-whitelisted event, got %q", terminalBuf.String())
+	}
+}
+
+func TestNewMirroredWriter_MirrorsInfoToTerminal(t *testing.T) {
+	var appBuf bytes.Buffer
+	var terminalBuf bytes.Buffer
+
+	writer := NewMirroredWriter(&appBuf, &terminalBuf)
+	input := []byte(`{"ts":"2026-03-03T01:30:21.123Z","level":"info","event":"updater.completed","component":"updater","msg":"done"}`)
+	if _, err := writer.Write(input); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if appBuf.Len() == 0 || terminalBuf.Len() == 0 {
+		t.Fatalf("expected mirrored output, got app=%q terminal=%q", appBuf.String(), terminalBuf.String())
+	}
+}

--- a/apps/backend/internal/space/handler/file_handler.go
+++ b/apps/backend/internal/space/handler/file_handler.go
@@ -9,15 +9,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/auth"
+	"taeu.kr/cohesion/internal/platform/logging"
 	"taeu.kr/cohesion/internal/platform/web"
 	"taeu.kr/cohesion/internal/space"
 )
@@ -125,7 +126,11 @@ func moveWithDestinationSwap(srcPath, destPath string) error {
 	}
 
 	if removeErr := os.RemoveAll(backupPath); removeErr != nil {
-		log.Printf("[WARN] move overwrite backup cleanup failed: %s: %v", backupPath, removeErr)
+		logging.Event(log.Warn(), logging.ComponentStorage, "warn.storage.cleanup_failed").
+			Str("operation", "move-overwrite-backup-cleanup").
+			Str("path", backupPath).
+			Err(removeErr).
+			Msg("cleanup failed")
 	}
 
 	return nil
@@ -164,13 +169,21 @@ func copyWithDestinationSwap(srcPath, destPath string, isDir bool) error {
 			return fmt.Errorf("failed to finalize copied data: %v; additionally failed to restore destination backup %q: %v", err, backupPath, restoreErr)
 		}
 		if cleanupErr := os.RemoveAll(stagedPath); cleanupErr != nil {
-			log.Printf("[WARN] copy overwrite staging cleanup failed: %s: %v", stagedPath, cleanupErr)
+			logging.Event(log.Warn(), logging.ComponentStorage, "warn.storage.cleanup_failed").
+				Str("operation", "copy-overwrite-stage-cleanup").
+				Str("path", stagedPath).
+				Err(cleanupErr).
+				Msg("cleanup failed")
 		}
 		return err
 	}
 
 	if removeErr := os.RemoveAll(backupPath); removeErr != nil {
-		log.Printf("[WARN] copy overwrite backup cleanup failed: %s: %v", backupPath, removeErr)
+		logging.Event(log.Warn(), logging.ComponentStorage, "warn.storage.cleanup_failed").
+			Str("operation", "copy-overwrite-backup-cleanup").
+			Str("path", backupPath).
+			Err(removeErr).
+			Msg("cleanup failed")
 	}
 
 	return nil
@@ -950,7 +963,10 @@ func (h *Handler) handleTrashRestore(w http.ResponseWriter, r *http.Request, spa
 					continue
 				}
 				if deleteErr := h.trashService.DeleteTrashItem(r.Context(), item.ID); deleteErr != nil {
-					log.Printf("[WARN] restore metadata cleanup failed (id=%d): %v", item.ID, deleteErr)
+					logging.Event(log.Warn(), logging.ComponentStorage, "warn.trash.metadata_cleanup_failed").
+						Int64("trash_id", item.ID).
+						Err(deleteErr).
+						Msg("trash metadata cleanup failed")
 				}
 				succeeded = append(succeeded, restoreSuccess{ID: item.ID, OriginalPath: item.OriginalPath})
 				continue
@@ -987,7 +1003,10 @@ func (h *Handler) handleTrashRestore(w http.ResponseWriter, r *http.Request, spa
 			continue
 		}
 		if deleteErr := h.trashService.DeleteTrashItem(r.Context(), item.ID); deleteErr != nil {
-			log.Printf("[WARN] restore metadata cleanup failed (id=%d): %v", item.ID, deleteErr)
+			logging.Event(log.Warn(), logging.ComponentStorage, "warn.trash.metadata_cleanup_failed").
+				Int64("trash_id", item.ID).
+				Err(deleteErr).
+				Msg("trash metadata cleanup failed")
 		}
 		succeeded = append(succeeded, restoreSuccess{ID: item.ID, OriginalPath: item.OriginalPath})
 	}
@@ -1810,7 +1829,10 @@ func (h *Handler) handleFileDownloadMultiple(w http.ResponseWriter, r *http.Requ
 	return h.streamZipDownload(w, zipFileName, func(zipWriter *zip.Writer) *web.Error {
 		for i, absPath := range absPaths {
 			if err := addToZip(zipWriter, absPath, filepath.Base(req.Paths[i])); err != nil {
-				log.Printf("Failed to add %s to ZIP: %v", absPath, err)
+				logging.Event(log.Warn(), logging.ComponentStorage, "warn.archive.zip_entry_failed").
+					Str("path", absPath).
+					Err(err).
+					Msg("failed to add zip entry")
 			}
 		}
 		return nil
@@ -1866,7 +1888,10 @@ func (h *Handler) handleFileDownloadMultipleTicket(w http.ResponseWriter, r *htt
 	zipTempPath, zipSize, zipErr := h.buildZipTempArchive(func(zipWriter *zip.Writer) *web.Error {
 		for i, absPath := range absPaths {
 			if err := addToZip(zipWriter, absPath, filepath.Base(req.Paths[i])); err != nil {
-				log.Printf("Failed to add %s to ZIP: %v", absPath, err)
+				logging.Event(log.Warn(), logging.ComponentStorage, "warn.archive.zip_entry_failed").
+					Str("path", absPath).
+					Err(err).
+					Msg("failed to add zip entry")
 			}
 		}
 		return nil
@@ -1908,7 +1933,10 @@ func (h *Handler) downloadFolderAsZip(w http.ResponseWriter, folderPath string, 
 func (h *Handler) writeFolderToZip(folderPath string, zipWriter *zip.Writer) *web.Error {
 	err := filepath.Walk(folderPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			log.Printf("Skipping file due to error: %s - %v", path, err)
+			logging.Event(log.Warn(), logging.ComponentStorage, "warn.archive.walk_skip").
+				Str("path", path).
+				Err(err).
+				Msg("skipping path during archive walk")
 			return nil
 		}
 		if info.Mode()&os.ModeSymlink != 0 {

--- a/apps/backend/main.go
+++ b/apps/backend/main.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"errors"
-	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -28,6 +28,7 @@ import (
 	"taeu.kr/cohesion/internal/config"
 	"taeu.kr/cohesion/internal/ftp"
 	"taeu.kr/cohesion/internal/platform/database"
+	"taeu.kr/cohesion/internal/platform/logging"
 	"taeu.kr/cohesion/internal/platform/web"
 	sftpserver "taeu.kr/cohesion/internal/sftp"
 	"taeu.kr/cohesion/internal/spa"
@@ -45,6 +46,11 @@ var (
 	appVersion   = "dev"
 	appCommit    = "local"
 	appBuildDate = ""
+	accessLogger = zerolog.New(io.Discard).
+			With().
+			Timestamp().
+			Str(logging.FieldComponent, logging.ComponentAccess).
+			Logger()
 )
 
 // 재시작 신호를 받기 위한 채널
@@ -52,7 +58,9 @@ var restartChan = make(chan bool, 1)
 var shutdownChan = make(chan struct{}, 1)
 
 func init() {
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.TimestampFieldName = logging.FieldTimestamp
+	zerolog.MessageFieldName = logging.FieldMessage
 }
 
 func resolveExecutableDir() (string, error) {
@@ -84,25 +92,58 @@ func openRootLogFile(fileName string) (*os.File, string, error) {
 	return logFile, logPath, nil
 }
 
-func configureRootLogger() (*os.File, string, error) {
-	logFile, logPath, err := openRootLogFile("app.log")
+func configureRootLoggers() (*os.File, *os.File, string, string, error) {
+	appLogFile, appLogPath, err := openRootLogFile("app.log")
 	if err != nil {
-		return nil, "", err
+		return nil, nil, "", "", err
+	}
+	accessLogFile, accessLogPath, err := openRootLogFile("access.log")
+	if err != nil {
+		_ = appLogFile.Close()
+		return nil, nil, "", "", err
 	}
 
-	if goEnv == "production" {
-		zerolog.TimestampFunc = func() time.Time {
-			return time.Now().UTC()
-		}
-		log.Logger = log.Output(logFile)
-		return logFile, logPath, nil
+	operationalWriter := logging.NewOperationalWriter(appLogFile, os.Stderr)
+	log.Logger = newOperationalLogger(operationalWriter)
+	accessLogger = newAccessLogger(accessLogFile)
+
+	return appLogFile, accessLogFile, appLogPath, accessLogPath, nil
+}
+
+func configureFallbackLoggers() {
+	// Keep terminal operational policy even when file sinks cannot be initialized.
+	log.Logger = newOperationalLogger(logging.NewOperationalWriter(io.Discard, os.Stderr))
+	// Do not drop access logs on sink initialization failures.
+	accessLogger = newAccessLogger(os.Stderr)
+}
+
+func newOperationalLogger(out io.Writer) zerolog.Logger {
+	return zerolog.New(out).With().Timestamp().Logger()
+}
+
+func newAccessLogger(out io.Writer) zerolog.Logger {
+	return zerolog.New(logging.NewKeyValueWriter(out)).
+		With().
+		Timestamp().
+		Str(logging.FieldComponent, logging.ComponentAccess).
+		Logger()
+}
+
+func emitAccessLog(r *http.Request, status, size int, duration time.Duration) {
+	event := accessLogger.Info().
+		Str(logging.FieldEvent, logging.EventHTTPAccess).
+		Str("method", r.Method).
+		Str("path", r.URL.Path)
+
+	if rawQuery := strings.TrimSpace(r.URL.RawQuery); rawQuery != "" {
+		event = event.Str("query", rawQuery)
 	}
 
-	log.Logger = log.Output(zerolog.MultiLevelWriter(
-		zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339},
-		logFile,
-	))
-	return logFile, logPath, nil
+	event.
+		Int("status", status).
+		Int("size", size).
+		Int64("duration_ms", duration.Milliseconds()).
+		Msg("http request served")
 }
 
 func writePIDFile() (func(), string, error) {
@@ -209,13 +250,7 @@ func createServer(db *sql.DB, restartChan chan bool, shutdownChan chan struct{})
 	finalHandler := authService.Middleware(mux)
 
 	finalLogHandler := hlogHandler(hlog.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
-		hlog.FromRequest(r).Info().
-			Str("method", r.Method).
-			Str("url", r.URL.String()).
-			Int("status", status).
-			Int("size", size).
-			Dur("duration", duration).
-			Msg("Access log")
+		emitAccessLog(r, status, size, duration)
 	})(finalHandler))
 
 	port := ":" + config.Conf.Server.Port
@@ -228,35 +263,64 @@ func createServer(db *sql.DB, restartChan chan bool, shutdownChan chan struct{})
 }
 
 func main() {
-	logFile, logPath, loggerErr := configureRootLogger()
+	appLogFile, accessLogFile, appLogPath, accessLogPath, loggerErr := configureRootLoggers()
 	if loggerErr != nil {
-		fmt.Fprintf(os.Stderr, "[Main] failed to initialize file logger: %v\n", loggerErr)
+		configureFallbackLoggers()
+		logging.Event(log.Error(), logging.ComponentMain, "error.logger.init_failed").
+			Err(loggerErr).
+			Msg("failed to initialize file log sinks; using stderr fallback")
 	} else {
-		defer logFile.Close()
-		log.Info().Str("path", logPath).Msg("[Main] App log file initialized")
+		defer appLogFile.Close()
+		defer accessLogFile.Close()
+		logging.Event(log.Info(), logging.ComponentMain, logging.EventServiceReady).
+			Str("service", "app-log").
+			Str("path", appLogPath).
+			Msg("service log sink ready")
+		logging.Event(log.Info(), logging.ComponentMain, logging.EventServiceReady).
+			Str("service", "access-log").
+			Str("path", accessLogPath).
+			Msg("service log sink ready")
 	}
 
 	pidCleanup, pidPath, pidErr := writePIDFile()
 	if pidErr != nil {
-		log.Warn().Err(pidErr).Msg("[Main] Failed to write PID file")
+		logging.Event(log.Warn(), logging.ComponentMain, "warn.pid.write_failed").
+			Err(pidErr).
+			Msg("failed to write pid file")
 	} else {
 		defer pidCleanup()
-		log.Info().Str("path", pidPath).Int("pid", os.Getpid()).Msg("[Main] PID file initialized")
+		logging.Event(log.Info(), logging.ComponentMain, logging.EventServiceReady).
+			Str("service", "pid-file").
+			Str("path", pidPath).
+			Int("pid", os.Getpid()).
+			Msg("service pid file ready")
 	}
 
-	log.Info().Msg("[Main] Starting Server...")
-	log.Info().Msgf("[Main] environment: %s", goEnv)
+	logging.Event(log.Info(), logging.ComponentMain, logging.EventBootStart).
+		Str("environment", goEnv).
+		Str("version", appVersion).
+		Str("commit", appCommit).
+		Str("build_date", appBuildDate).
+		Msg("server booting")
 
 	// 설정 로드
 	config.SetConfig(goEnv)
+	logging.Event(log.Info(), logging.ComponentConfig, logging.EventConfigLoaded).
+		Str("environment", goEnv).
+		Str("config_dir", config.ConfigDir()).
+		Msg("configuration loaded")
 
 	// 데이터베이스 연결 설정
 	db, err := database.NewDB()
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to connect to database")
+		logging.Event(log.Fatal(), logging.ComponentDB, "fatal.db.connect_failed").
+			Err(err).
+			Msg("failed to connect database")
 	}
 	defer db.Close()
-	log.Info().Msg("Database connected successfully.")
+	logging.Event(log.Info(), logging.ComponentDB, logging.EventDatabaseReady).
+		Str("datasource_url", config.Conf.Datasource.URL).
+		Msg("database connected")
 
 	// OS 시그널 핸들링 (Ctrl+C)
 	sigChan := make(chan os.Signal, 1)
@@ -267,21 +331,53 @@ func main() {
 		// 서버 생성
 		server, ftpService, sftpService, err := createServer(db, restartChan, shutdownChan)
 		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create server")
+			logging.Event(log.Fatal(), logging.ComponentServer, "fatal.server.create_failed").
+				Err(err).
+				Msg("failed to create server")
 		}
 		if err := ftpService.Start(); err != nil {
-			log.Fatal().Err(err).Msg("Failed to start FTP server")
+			logging.Event(log.Fatal(), logging.ComponentServer, "fatal.service.start_failed").
+				Str("service", "ftp").
+				Int("port", ftpService.Port()).
+				Err(err).
+				Msg("failed to start service")
 		}
+		logging.Event(log.Info(), logging.ComponentServer, logging.EventServiceReady).
+			Str("service", "ftp").
+			Bool("enabled", ftpService.Enabled()).
+			Int("port", ftpService.Port()).
+			Msg("service status updated")
 		if err := sftpService.Start(); err != nil {
 			if stopErr := ftpService.Stop(); stopErr != nil {
-				log.Error().Err(stopErr).Msg("FTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "ftp").
+					Err(stopErr).
+					Msg("failed to stop service")
 			}
-			log.Fatal().Err(err).Msg("Failed to start SFTP server")
+			logging.Event(log.Fatal(), logging.ComponentServer, "fatal.service.start_failed").
+				Str("service", "sftp").
+				Int("port", sftpService.Port()).
+				Err(err).
+				Msg("failed to start service")
 		}
+		logging.Event(log.Info(), logging.ComponentServer, logging.EventServiceReady).
+			Str("service", "sftp").
+			Bool("enabled", sftpService.Enabled()).
+			Int("port", sftpService.Port()).
+			Msg("service status updated")
 
 		port := config.Conf.Server.Port
-		log.Info().Msgf("Server is running on port %s", port)
-		log.Info().Msg("Press Ctrl+C to stop")
+		logging.Event(log.Info(), logging.ComponentServer, logging.EventServiceReady).
+			Str("service", "http").
+			Str("port", port).
+			Msg("service status updated")
+		logging.Event(log.Info(), logging.ComponentServer, logging.EventServiceReady).
+			Str("service", "webdav").
+			Bool("enabled", config.Conf.Server.WebdavEnabled).
+			Msg("service status updated")
+		logging.Event(log.Info(), logging.ComponentServer, logging.EventServerReady).
+			Str("port", port).
+			Msg("server ready")
 
 		// 서버를 별도 고루틴에서 실행
 		serverErr := make(chan error, 1)
@@ -294,65 +390,111 @@ func main() {
 		// 재시작 또는 종료 신호 대기
 		select {
 		case <-sigChan:
-			log.Info().Msg("[Main] Shutdown signal received")
+			logging.Event(log.Info(), logging.ComponentServer, logging.EventServerShutdownSignal).
+				Str("source", "signal").
+				Msg("shutdown requested")
 			if err := sftpService.Stop(); err != nil {
-				log.Error().Err(err).Msg("SFTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "sftp").
+					Err(err).
+					Msg("failed to stop service")
 			}
 			if err := ftpService.Stop(); err != nil {
-				log.Error().Err(err).Msg("FTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "ftp").
+					Err(err).
+					Msg("failed to stop service")
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if err := server.Shutdown(ctx); err != nil {
-				log.Error().Err(err).Msg("Server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.server.shutdown_failed").
+					Err(err).
+					Msg("failed to shutdown server")
 			}
-			log.Info().Msg("[Main] Server stopped")
+			logging.Event(log.Info(), logging.ComponentServer, logging.EventServerShutdownDone).
+				Str("source", "signal").
+				Msg("server shutdown completed")
 			return
 
 		case <-restartChan:
-			log.Info().Msg("[Main] Restart signal received")
+			logging.Event(log.Info(), logging.ComponentServer, logging.EventServerRestartRequest).
+				Msg("restart requested")
 			if err := sftpService.Stop(); err != nil {
-				log.Error().Err(err).Msg("SFTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "sftp").
+					Err(err).
+					Msg("failed to stop service")
 			}
 			if err := ftpService.Stop(); err != nil {
-				log.Error().Err(err).Msg("FTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "ftp").
+					Err(err).
+					Msg("failed to stop service")
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			if err := server.Shutdown(ctx); err != nil {
-				log.Error().Err(err).Msg("Server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.server.shutdown_failed").
+					Err(err).
+					Msg("failed to shutdown server")
 			}
 			cancel()
 
 			// 설정 다시 로드
-			log.Info().Msg("[Main] Reloading configuration...")
 			config.SetConfig(goEnv)
-			log.Info().Msgf("[Main] Restarting with new port: %s", config.Conf.Server.Port)
+			logging.Event(log.Info(), logging.ComponentConfig, logging.EventConfigLoaded).
+				Str("environment", goEnv).
+				Str("config_dir", config.ConfigDir()).
+				Msg("configuration loaded")
+			logging.Event(log.Info(), logging.ComponentServer, logging.EventServerRestarted).
+				Str("port", config.Conf.Server.Port).
+				Msg("restart completed")
 		// 루프 계속 (재시작)
 
 		case <-shutdownChan:
-			log.Info().Msg("[Main] Shutdown signal received from updater")
+			logging.Event(log.Info(), logging.ComponentServer, logging.EventServerShutdownSignal).
+				Str("source", "updater").
+				Msg("shutdown requested")
 			if err := sftpService.Stop(); err != nil {
-				log.Error().Err(err).Msg("SFTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "sftp").
+					Err(err).
+					Msg("failed to stop service")
 			}
 			if err := ftpService.Stop(); err != nil {
-				log.Error().Err(err).Msg("FTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "ftp").
+					Err(err).
+					Msg("failed to stop service")
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if err := server.Shutdown(ctx); err != nil {
-				log.Error().Err(err).Msg("Server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.server.shutdown_failed").
+					Err(err).
+					Msg("failed to shutdown server")
 			}
-			log.Info().Msg("[Main] Server stopped for self-update")
+			logging.Event(log.Info(), logging.ComponentServer, logging.EventServerShutdownDone).
+				Str("source", "updater").
+				Msg("server shutdown completed")
 			return
 
 		case err := <-serverErr:
 			if stopErr := sftpService.Stop(); stopErr != nil {
-				log.Error().Err(stopErr).Msg("SFTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "sftp").
+					Err(stopErr).
+					Msg("failed to stop service")
 			}
 			if stopErr := ftpService.Stop(); stopErr != nil {
-				log.Error().Err(stopErr).Msg("FTP server shutdown error")
+				logging.Event(log.Error(), logging.ComponentServer, "error.service.stop_failed").
+					Str("service", "ftp").
+					Err(stopErr).
+					Msg("failed to stop service")
 			}
-			log.Fatal().Err(err).Msg("Server error")
+			logging.Event(log.Fatal(), logging.ComponentServer, "fatal.server.runtime_failed").
+				Err(err).
+				Msg("server runtime failure")
 			return
 		}
 	}
@@ -389,7 +531,10 @@ func resolveJWTSecret() (string, error) {
 		return "", errors.New("COHESION_JWT_SECRET must be at least 32 characters in production")
 	}
 
-	log.Info().Str("path", secretFilePath).Msg("JWT secret loaded from file")
+	logging.Event(log.Info(), logging.ComponentAuth, logging.EventServiceReady).
+		Str("service", "jwt-secret").
+		Str("path", secretFilePath).
+		Msg("service status updated")
 	return secret, nil
 }
 

--- a/apps/backend/main_test.go
+++ b/apps/backend/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"taeu.kr/cohesion/internal/platform/logging"
 )
 
 func TestRegisterWebDAVRoutes_NoRedirectForBasePath(t *testing.T) {
@@ -27,5 +32,47 @@ func TestRegisterWebDAVRoutes_NoRedirectForBasePath(t *testing.T) {
 				t.Fatalf("expected no redirect location header, got %q", location)
 			}
 		})
+	}
+}
+
+func TestEmitAccessLog_IncludesQueryWhenPresent(t *testing.T) {
+	previousLogger := accessLogger
+	defer func() {
+		accessLogger = previousLogger
+	}()
+
+	var buffer bytes.Buffer
+	accessLogger = newAccessLogger(&buffer)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/search?q=hello&sort=asc", nil)
+	emitAccessLog(req, http.StatusOK, 128, 250*time.Millisecond)
+
+	line := buffer.String()
+	if !strings.Contains(line, "event="+logging.EventHTTPAccess) {
+		t.Fatalf("expected access event in log line, got %q", line)
+	}
+	if !strings.Contains(line, "path=/api/search") {
+		t.Fatalf("expected path field in log line, got %q", line)
+	}
+	if !strings.Contains(line, `query="q=hello&sort=asc"`) {
+		t.Fatalf("expected query field in log line, got %q", line)
+	}
+}
+
+func TestEmitAccessLog_OmitsQueryWhenEmpty(t *testing.T) {
+	previousLogger := accessLogger
+	defer func() {
+		accessLogger = previousLogger
+	}()
+
+	var buffer bytes.Buffer
+	accessLogger = newAccessLogger(&buffer)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	emitAccessLog(req, http.StatusOK, 64, 50*time.Millisecond)
+
+	line := buffer.String()
+	if strings.Contains(line, "query=") {
+		t.Fatalf("expected no query field for empty query string, got %q", line)
 	}
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -99,3 +99,66 @@ apps/backend/
     -   `SetConfig("production")`이 호출되어 `viper`가 `config.prod.yaml` 파일을 로드함.
     -   프로덕션용 설정으로 서버가 동작함.
     -   이 서버 하나가 API 요청(`_API 경로`)과 웹 UI(`/` 경로)를 모두 처리하는 독립 앱으로 기능함.
+
+---
+
+## 운영 로그 가이드 (Operational Logging)
+
+### 로그 채널
+
+- 운영 로그(Operational): 서비스 상태/라이프사이클/경고/오류
+- 접근 로그(Access): HTTP 요청/응답 메타데이터
+
+### 로그 파일 위치
+
+백엔드 실행파일 기준 `logs/` 디렉토리에 기록됨.
+
+- `logs/app.log`: 운영 로그 전체
+- `logs/access.log`: HTTP access 로그 전용
+- `logs/updater.log`: 업데이터 실행 로그
+
+### 터미널 출력 정책
+
+- 터미널에는 운영 상태 확인에 필요한 이벤트만 출력됨.
+- `INFO`: 필수 라이프사이클 이벤트(`boot.*`, `config.loaded`, `db.ready`, `service.ready`, `server.*`)
+- `WARN/ERROR/FATAL`: 항상 출력
+- `http.access` 이벤트는 터미널에 출력하지 않고 `logs/access.log`로만 기록
+
+### 로그 형식
+
+- 터미널(운영 로그): log4j2 유사 패턴 형식
+  - `<ts> <LEVEL> [<component>] <event> - <msg> <extras>`
+  - 예시:
+    - `2026-03-03T01:34:32+09:00 INFO [server] server.ready - server ready port=38080`
+    - `2026-03-03T01:34:33+09:00 INFO [server] server.shutdown_signal - shutdown requested source=signal`
+- 파일(`logs/app.log`, `logs/access.log`, `logs/updater.log`): 영문 `key=value` 단일 라인 형식 유지
+  - 공통 핵심 필드: `ts`, `level`, `event`, `component`, `msg`
+  - Access 추가 필드(선택): `query`
+  - 예시:
+    - `ts=2026-03-03T01:34:32+09:00 level=INFO event=server.ready component=server msg=\"server ready\" port=38080`
+    - `ts=2026-03-03T01:34:33+09:00 level=INFO event=http.access component=access msg=\"http request served\" method=GET path=/api/search query=\"q=hello&sort=asc\" status=200`
+
+### 트러블슈팅 명령
+
+```bash
+# 운영 라이프사이클 이벤트 추적 (파일 기준)
+rg "event=(boot\\.|config\\.loaded|db\\.ready|service\\.ready|server\\.)" logs/app.log
+
+# 오류/치명 로그 확인 (파일 기준)
+rg "level=(ERROR|FATAL)" logs/app.log
+
+# Access 로그 실시간 확인
+tail -f logs/access.log
+
+# 특정 API 요청 필터링 (예: restart)
+rg "event=http\\.access .*path=/api/system/restart" logs/access.log
+
+# updater 런타임 오류 확인
+rg "event=error\\.updater\\." logs/updater.log
+```
+
+### 운영자 확인 순서
+
+- 터미널에서 현재 상태를 빠르게 확인한다. (부팅/재시작/종료, WARN/ERROR/FATAL)
+- 상세 원인 분석이나 자동화 필터링은 파일 로그(`app.log`, `access.log`, `updater.log`)에서 수행한다.
+- `http.access`는 터미널에 출력되지 않으므로, 요청 단위 추적은 반드시 `logs/access.log`를 사용한다.


### PR DESCRIPTION
## 요약
운영 중 터미널 가독성과 파일 로그 분석 가능성을 동시에 유지하면서, 로그 sink 초기화 실패 시 access 로그가 유실될 수 있는 리스크를 제거했습니다.

- 문제: 터미널/파일 로그 포맷 혼재, access 로그 채널 분리 미흡, sink 초기화 실패 시 access logger 유실 가능성
- 해결: 운영/접근 로그 채널 분리, 터미널 log4j2 유사 패턴 렌더링, 파일 `key=value` 유지, fallback logger 및 access query 필드 보강
- 기대 효과: 운영 가독성 향상 + 장애 시 로그 유실 방지 + 요청 분석 정확도 향상

## 관련 이슈
Closes #171

## 변경 사항
- 공통 로깅 계약/포맷 유틸 추가
  - `internal/platform/logging` (`event/component` 상수, terminal info whitelist, writer 분기)
- 백엔드 메인 로거 구조 정리
  - 운영 로그: `logs/app.log` + 터미널 패턴 출력
  - 접근 로그: `logs/access.log` 전용 (`http.access`)
- 터미널 렌더 패턴 도입
  - `<ts> <LEVEL> [<component>] <event> - <msg> <extras>`
- 업데이터 로그 정렬
  - 업데이터 터미널도 동일 패턴 계약 적용
  - 업데이터 파일 로그는 `key=value` 유지
- 코드리뷰 후속 보강
  - sink 초기화 실패 시 stderr fallback 로거 적용 (access 유실 방지)
  - access 로그에 `query`(선택) 필드 추가
- 문서 업데이트
  - `docs/backend.md`에 터미널/파일 로그 정책, 예시, 트러블슈팅 반영

## 범위
### In Scope
- 백엔드 로깅 계약/출력 경로/런타임 이벤트 로깅 정리
- updater 로깅 정렬
- 관련 테스트 및 운영 문서 반영

### Out of Scope
- Audit Log 기능 확장
- 외부 로그 수집 시스템 연동
- 보안 마스킹 정책 확장

## 테스트/검증
- 자동 검증
  - `cd apps/backend && go test ./...` ✅
  - `go test ./internal/platform/logging -v` ✅
  - `go test ./cmd/updater -v` ✅
- 통합 런타임 검증 ✅
  - startup/restart/shutdown 라이프사이클 이벤트 터미널 패턴 확인
  - `http.access` 터미널 미출력 + `logs/access.log` 기록 확인
  - `app.log/access.log/updater.log` `key=value` 유지 확인
  - updater 터미널 패턴 출력 확인

## 리스크 및 대응
- 잠재 리스크: 기존 터미널 `key=value` 파싱 스크립트 회귀 가능
- 대응: 파일 로그(`app.log/access.log/updater.log`)는 구조화 `key=value` 유지
- 롤백: writer 경로를 기존 terminal `key=value` 출력으로 되돌리고 main/updater wiring revert

## 리뷰 가이드
우선 확인 파일:
- `apps/backend/internal/platform/logging/writer.go`
- `apps/backend/main.go`
- `apps/backend/cmd/updater/main.go`
- `apps/backend/main_test.go`
- `docs/backend.md`

검토 포인트:
- terminal/file sink 분리 로직
- fallback logger 경로에서 access 유실 방지
- access query 필드 조건부 출력

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #171`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트 반영
- [x] 브레이킹 변경 없음