### PR TITLE
fix: 시스템 browse 권한 경계와 트리 키 충돌 고정

### DIFF
--- a/apps/backend/internal/auth/middleware_test.go
+++ b/apps/backend/internal/auth/middleware_test.go
@@ -134,6 +134,43 @@ func TestMiddleware_DeniesWhenSpacePermissionIsMissing(t *testing.T) {
 	}
 }
 
+func TestMiddleware_DeniesSystemBrowseEndpointsWithoutSpaceWrite(t *testing.T) {
+	authSvc, accountSvc, db := setupAuthTestService(t)
+	defer db.Close()
+	_, _ = seedAuthUsers(t, accountSvc)
+
+	userToken := issueAccessTokenForTestUser(t, authSvc, testUserUsername)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "browse endpoint",
+			url:  "/api/browse?path=%2F",
+		},
+		{
+			name: "base directories endpoint",
+			url:  "/api/browse/base-directories",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			req.AddCookie(&http.Cookie{Name: auth.AccessCookieName, Value: userToken})
+
+			rec := executeMiddlewareRequest(t, authSvc, req, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+			}
+		})
+	}
+}
+
 func TestMiddleware_AllowsAndInjectsClaims_WhenAuthorized(t *testing.T) {
 	authSvc, accountSvc, db := setupAuthTestService(t)
 	defer db.Close()

--- a/apps/backend/internal/auth/permissions.go
+++ b/apps/backend/internal/auth/permissions.go
@@ -56,10 +56,7 @@ func requiredPermissionForRequest(r *http.Request) (string, bool) {
 		return PermissionSpaceWrite, true
 	}
 	if path == "/api/browse" {
-		if r.URL.Query().Get("system") == "true" {
-			return PermissionSpaceWrite, true
-		}
-		return PermissionSpaceRead, true
+		return PermissionSpaceWrite, true
 	}
 	if path == "/api/search/files" && method == http.MethodGet {
 		return PermissionFileRead, true

--- a/apps/backend/internal/auth/permissions_test.go
+++ b/apps/backend/internal/auth/permissions_test.go
@@ -54,6 +54,65 @@ func TestRequiredPermissionForRequest_SearchEndpoint(t *testing.T) {
 	}
 }
 
+func TestRequiredPermissionForRequest_BrowseEndpointUsesSpaceWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawQuery string
+	}{
+		{
+			name:     "without system query",
+			rawQuery: "",
+		},
+		{
+			name:     "with legacy system query",
+			rawQuery: "system=true",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := &http.Request{
+				Method: http.MethodGet,
+				URL: &url.URL{
+					Path:     "/api/browse",
+					RawQuery: tc.rawQuery,
+				},
+			}
+
+			got, ok := requiredPermissionForRequest(req)
+			if !ok {
+				t.Fatal("expected permission mapping for browse endpoint")
+			}
+			if got != PermissionSpaceWrite {
+				t.Fatalf("expected %q, got %q", PermissionSpaceWrite, got)
+			}
+		})
+	}
+}
+
+func TestRequiredPermissionForRequest_BaseDirectoriesEndpointUsesSpaceWrite(t *testing.T) {
+	t.Parallel()
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL: &url.URL{
+			Path: "/api/browse/base-directories",
+		},
+	}
+
+	got, ok := requiredPermissionForRequest(req)
+	if !ok {
+		t.Fatal("expected permission mapping for base directories endpoint")
+	}
+	if got != PermissionSpaceWrite {
+		t.Fatalf("expected %q, got %q", PermissionSpaceWrite, got)
+	}
+}
+
 func TestRequiredPermissionForRequest_SpaceUsageAndQuota(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/apps/backend/internal/browse/handler/browse_handler.go
+++ b/apps/backend/internal/browse/handler/browse_handler.go
@@ -1,12 +1,9 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"taeu.kr/cohesion/internal/browse"
 	"taeu.kr/cohesion/internal/platform/web"
@@ -31,29 +28,6 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("/api/browse/base-directories", web.Handler(h.handleBaseDirectories))
 }
 
-// isPathAllowed는 경로가 등록된 Space 내부인지 확인합니다.
-func (h *Handler) isPathAllowed(ctx context.Context, requestPath string) (bool, error) {
-	cleanPath := filepath.Clean(requestPath)
-
-	spaces, err := h.spaceService.GetAllSpaces(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	if len(spaces) == 0 {
-		return true, nil
-	}
-
-	for _, s := range spaces {
-		spacePath := filepath.Clean(s.SpacePath)
-		if cleanPath == spacePath || strings.HasPrefix(cleanPath, spacePath+string(filepath.Separator)) {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 func (h *Handler) handleBaseDirectories(w http.ResponseWriter, r *http.Request) *web.Error {
 	dirs := h.browseService.GetBaseDirectories()
 	w.Header().Set("Content-Type", "application/json")
@@ -70,29 +44,10 @@ func (h *Handler) handleBaseDirectories(w http.ResponseWriter, r *http.Request) 
 
 func (h *Handler) handleBrowse(w http.ResponseWriter, r *http.Request) *web.Error {
 	path := r.URL.Query().Get("path")
-	systemMode := r.URL.Query().Get("system") == "true"
 
 	targetPath := path
 	if targetPath == "" {
 		targetPath = h.browseService.GetInitialBrowseRoot()
-	}
-
-	// system=true이면 Space 검증 스킵 (Space 생성용)
-	if !systemMode {
-		allowed, err := h.isPathAllowed(r.Context(), targetPath)
-		if err != nil {
-			return &web.Error{
-				Code:    http.StatusInternalServerError,
-				Message: "Failed to validate path",
-				Err:     err,
-			}
-		}
-		if !allowed {
-			return &web.Error{
-				Code:    http.StatusForbidden,
-				Message: "Access denied: path is not within any allowed Space",
-			}
-		}
 	}
 
 	files, err := h.browseService.ListDirectory(false, targetPath)

--- a/apps/backend/internal/browse/handler/browse_handler_test.go
+++ b/apps/backend/internal/browse/handler/browse_handler_test.go
@@ -1,0 +1,63 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"taeu.kr/cohesion/internal/browse"
+)
+
+func TestHandleBrowseTreatsRequestsAsSystemBrowse(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	visibleDir := filepath.Join(tempDir, "visible")
+	if err := os.Mkdir(visibleDir, 0o755); err != nil {
+		t.Fatalf("failed to create test directory: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		rawQuery string
+	}{
+		{
+			name:     "without system query",
+			rawQuery: "path=" + url.QueryEscape(tempDir),
+		},
+		{
+			name:     "with legacy system query",
+			rawQuery: "path=" + url.QueryEscape(tempDir) + "&system=true",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := NewHandler(browse.NewService(), nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/browse?"+tc.rawQuery, nil)
+			rec := httptest.NewRecorder()
+
+			if webErr := h.handleBrowse(rec, req); webErr != nil {
+				t.Fatalf("expected no error, got %+v", webErr)
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+			}
+
+			var payload []browse.FileInfo
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if len(payload) == 0 {
+				t.Fatalf("expected at least one entry in response, got %d", len(payload))
+			}
+		})
+	}
+}

--- a/apps/frontend/src/components/layout/MainLayout/MainSider.test.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/MainSider.test.tsx
@@ -1,0 +1,164 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MainSider from './MainSider';
+
+const h = vi.hoisted(() => {
+  const navigate = vi.fn();
+  const deleteSpace = vi.fn();
+  const permissionsState = {
+    permissions: [] as string[],
+  };
+  const browseState = {
+    selectedPath: '/',
+    selectedSpace: null as { id: number } | null,
+  };
+  const spaceState = {
+    deleteSpace,
+  };
+
+  return {
+    navigate,
+    deleteSpace,
+    permissionsState,
+    browseState,
+    spaceState,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router', () => ({
+  useLocation: () => ({ pathname: '/' }),
+  useNavigate: () => h.navigate,
+}));
+
+vi.mock('@/features/auth/useAuth', () => ({
+  useAuth: () => ({
+    user: { permissions: h.permissionsState.permissions },
+  }),
+}));
+
+vi.mock('@/stores/spaceStore', () => ({
+  useSpaceStore: (selector: (state: typeof h.spaceState) => unknown) => selector(h.spaceState),
+}));
+
+vi.mock('@/stores/browseStore', () => ({
+  useBrowseStore: (selector: (state: typeof h.browseState) => unknown) => selector(h.browseState),
+}));
+
+vi.mock('@/features/space/components/DirectorySetupModal', () => ({
+  default: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="directory-setup-modal" data-open={isOpen ? 'true' : 'false'} />
+  ),
+}));
+
+vi.mock('@/features/browse/components/FolderTree', () => ({
+  default: () => <div data-testid="folder-tree" />,
+}));
+
+vi.mock('@/components/common/SidePanelShell', () => ({
+  default: ({ title, leftAction, rightAction, children }: {
+    title: string;
+    leftAction?: ReactNode;
+    rightAction?: ReactNode;
+    children: ReactNode;
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      {leftAction}
+      {rightAction}
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@ant-design/icons', () => ({
+  PlusOutlined: () => null,
+  CloseOutlined: () => null,
+}));
+
+vi.mock('antd', () => ({
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+  Layout: {
+    Sider: ({ children }: { children: ReactNode }) => (
+      <aside data-testid="sider">{children}</aside>
+    ),
+  },
+  App: {
+    useApp: () => ({
+      message: {
+        success: vi.fn(),
+        error: vi.fn(),
+      },
+      modal: {
+        confirm: vi.fn(),
+      },
+    }),
+  },
+  theme: {
+    useToken: () => ({
+      token: {
+        colorBgContainer: '#ffffff',
+      },
+    }),
+  },
+  Tree: {
+    DirectoryTree: ({ onSelect }: { onSelect?: (keys: string[]) => void }) => (
+      <button type="button" data-testid="trash-entry" onClick={() => onSelect?.(['trash-action'])}>
+        trash
+      </button>
+    ),
+  },
+}));
+
+describe('MainSider space write policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.permissionsState.permissions = [];
+    h.browseState.selectedPath = '/';
+    h.browseState.selectedSpace = null;
+  });
+
+  it('shows add-space action and opens modal for users with space.write', async () => {
+    h.permissionsState.permissions = ['space.write'];
+    const user = userEvent.setup();
+
+    const view = render(<MainSider />);
+
+    const addButton = view.queryByRole('button', { name: 'mainSider.addSpace' });
+    if (!addButton) {
+      throw new Error('expected add-space button to be rendered');
+    }
+
+    expect(view.getByTestId('directory-setup-modal').getAttribute('data-open')).toBe('false');
+    await user.click(addButton);
+    expect(view.getByTestId('directory-setup-modal').getAttribute('data-open')).toBe('true');
+  });
+
+  it('hides add-space action and keeps modal closed without space.write', async () => {
+    h.permissionsState.permissions = ['space.read'];
+    const user = userEvent.setup();
+
+    const view = render(<MainSider />);
+
+    expect(view.queryByRole('button', { name: 'mainSider.addSpace' })).toBeNull();
+    expect(view.getByTestId('directory-setup-modal').getAttribute('data-open')).toBe('false');
+
+    await user.click(view.getByTestId('trash-entry'));
+    expect(view.getByTestId('directory-setup-modal').getAttribute('data-open')).toBe('false');
+  });
+});

--- a/apps/frontend/src/features/browse/components/FolderTree.test.tsx
+++ b/apps/frontend/src/features/browse/components/FolderTree.test.tsx
@@ -1,0 +1,252 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FolderTree from './FolderTree';
+import type { FileNode } from '../types';
+
+const h = vi.hoisted(() => {
+  const fetchBaseDirectories = vi.fn();
+  const fetchDirectoryContents = vi.fn();
+  const fetchSpaceDirectoryContents = vi.fn();
+  const fetchSpaces = vi.fn();
+  const openContextMenu = vi.fn();
+  const onSelect = vi.fn();
+
+  const spaceState = {
+    spaces: [],
+    error: null as Error | null,
+    fetchSpaces,
+  };
+
+  const browseState = {
+    treeRefreshVersion: 0,
+    treeInvalidationTargets: [] as Array<{ path: string; spaceId?: number }>,
+    selectedPath: '',
+    selectedSpace: undefined,
+  };
+
+  return {
+    fetchBaseDirectories,
+    fetchDirectoryContents,
+    fetchSpaceDirectoryContents,
+    fetchSpaces,
+    openContextMenu,
+    onSelect,
+    spaceState,
+    browseState,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/stores/spaceStore', () => ({
+  useSpaceStore: (selector: (state: typeof h.spaceState) => unknown) => selector(h.spaceState),
+}));
+
+vi.mock('@/stores/browseStore', () => ({
+  useBrowseStore: (selector: (state: typeof h.browseState) => unknown) => selector(h.browseState),
+}));
+
+vi.mock('@/stores/contextMenuStore', () => ({
+  useContextMenuStore: (selector: (state: { openContextMenu: typeof h.openContextMenu }) => unknown) =>
+    selector({ openContextMenu: h.openContextMenu }),
+}));
+
+vi.mock('../hooks/useBrowseApi', () => ({
+  useBrowseApi: () => ({
+    isLoading: false,
+    error: null,
+    fetchBaseDirectories: h.fetchBaseDirectories,
+    fetchDirectoryContents: h.fetchDirectoryContents,
+    fetchSpaceDirectoryContents: h.fetchSpaceDirectoryContents,
+  }),
+}));
+
+vi.mock('@ant-design/icons', () => ({
+  DeleteOutlined: () => null,
+}));
+
+vi.mock('antd', () => {
+  type MockTreeNode = {
+    title: unknown;
+    key: string;
+    isLeaf: boolean;
+    children?: MockTreeNode[];
+  };
+
+  const DirectoryTree = ({
+    treeData = [],
+    expandedKeys = [],
+    onExpand,
+    onSelect,
+  }: {
+    treeData?: MockTreeNode[];
+    expandedKeys?: Array<string>;
+    onExpand?: (keys: string[]) => void;
+    onSelect?: (keys: string[], info: { node: { key: string; isLeaf: boolean } }) => void;
+  }) => {
+    const expandedKeySet = new Set((expandedKeys ?? []).map((key) => String(key)));
+
+    const toggleNode = (key: string) => {
+      const next = new Set(expandedKeySet);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      onExpand?.(Array.from(next));
+    };
+
+    const selectNode = (key: string, isLeaf: boolean) => {
+      onSelect?.([key], { node: { key, isLeaf } });
+    };
+
+    const renderNodes = (nodes: MockTreeNode[]) =>
+      nodes.map((node) => {
+        const key = String(node.key);
+        return (
+          <div key={key} data-testid="tree-node" data-key={key} data-title={String(node.title)}>
+            <button type="button" data-testid="tree-switcher" data-key={key} onClick={() => toggleNode(key)}>
+              toggle
+            </button>
+            <button type="button" data-testid="tree-selector" data-key={key} onClick={() => selectNode(key, node.isLeaf)}>
+              {String(node.title)}
+            </button>
+            {expandedKeySet.has(key) && node.children ? <div>{renderNodes(node.children)}</div> : null}
+          </div>
+        );
+      });
+
+    return <div data-testid="tree">{renderNodes(treeData)}</div>;
+  };
+
+  return {
+    Tree: { DirectoryTree },
+    Spin: () => <div data-testid="spin" />,
+    Alert: ({ message, description, action }: { message?: string; description?: string; action?: ReactNode }) => (
+      <div data-testid="alert">
+        {message}
+        {description}
+        {action}
+      </div>
+    ),
+    Button: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+      <button type="button" onClick={onClick}>
+        {children ?? 'button'}
+      </button>
+    ),
+  };
+});
+
+function directory(path: string, name: string): FileNode {
+  return {
+    name,
+    path,
+    isDir: true,
+    modTime: '2026-03-02T00:00:00Z',
+    size: 0,
+  };
+}
+
+function getSwitcherByKey(key: string): HTMLButtonElement {
+  const switcher = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="tree-switcher"]'))
+    .find((element: HTMLButtonElement) => element.getAttribute('data-key') === key);
+  if (!switcher) {
+    throw new Error(`switcher not found: ${key}`);
+  }
+  return switcher as HTMLButtonElement;
+}
+
+function getSelectorByKey(key: string): HTMLButtonElement {
+  const selector = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="tree-selector"]'))
+    .find((element: HTMLButtonElement) => element.getAttribute('data-key') === key);
+  if (!selector) {
+    throw new Error(`selector not found: ${key}`);
+  }
+  return selector as HTMLButtonElement;
+}
+
+function getVisibleNodeKeys(): string[] {
+  return Array.from(document.querySelectorAll<HTMLDivElement>('[data-testid="tree-node"]'))
+    .map((node: HTMLDivElement) => node.getAttribute('data-key'))
+    .filter((key): key is string => Boolean(key));
+}
+
+async function waitForNodeKey(key: string): Promise<void> {
+  await vi.waitFor(() => {
+    const keys = getVisibleNodeKeys();
+    expect(keys).toContain(key);
+  });
+}
+
+describe('FolderTree (space directory mode)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    h.fetchBaseDirectories.mockResolvedValue([
+      directory('/Users/tester', 'Home'),
+      directory('/', '/'),
+      directory('/dev', '/dev'),
+    ]);
+
+    h.fetchDirectoryContents.mockImplementation(async (path: string) => {
+      if (path === '/') {
+        return [
+          directory('/dev', 'dev'),
+          directory('/usr', 'usr'),
+        ];
+      }
+      return [];
+    });
+  });
+
+  it('keeps unique keys and stable child count while repeatedly toggling root slash', async () => {
+    const user = userEvent.setup();
+    render(<FolderTree onSelect={h.onSelect} showBaseDirectories />);
+
+    await vi.waitFor(() => {
+      expect(h.fetchBaseDirectories).toHaveBeenCalledTimes(1);
+    });
+    await waitForNodeKey('base::/');
+
+    for (let index = 0; index < 6; index += 1) {
+      await user.click(getSwitcherByKey('base::/'));
+      const keys = getVisibleNodeKeys();
+      expect(new Set(keys).size).toBe(keys.length);
+
+      const visibleDevChildren = Array.from(document.querySelectorAll<HTMLDivElement>('[data-testid="tree-node"]'))
+        .filter((node: HTMLDivElement) => node.getAttribute('data-title') === 'dev').length;
+
+      if (index % 2 === 0) {
+        expect(visibleDevChildren).toBe(1);
+      } else {
+        expect(visibleDevChildren).toBe(0);
+      }
+    }
+
+    expect(h.fetchDirectoryContents).toHaveBeenCalledTimes(1);
+    expect(h.fetchDirectoryContents).toHaveBeenCalledWith('/');
+  });
+
+  it('decodes scoped keys before forwarding selection path', async () => {
+    const user = userEvent.setup();
+    render(<FolderTree onSelect={h.onSelect} showBaseDirectories />);
+
+    await vi.waitFor(() => {
+      expect(h.fetchBaseDirectories).toHaveBeenCalledTimes(1);
+    });
+    await waitForNodeKey('base::/');
+
+    await user.click(getSelectorByKey('base::/'));
+    expect(h.onSelect).toHaveBeenLastCalledWith('/');
+
+    await waitForNodeKey('system::/dev');
+    await user.click(getSelectorByKey('system::/dev'));
+    expect(h.onSelect).toHaveBeenLastCalledWith('/dev');
+  });
+});

--- a/apps/frontend/src/features/browse/components/FolderTree.tsx
+++ b/apps/frontend/src/features/browse/components/FolderTree.tsx
@@ -15,18 +15,52 @@ import { useTranslation } from 'react-i18next';
 
 type DirectoryTreeProps = GetProps<typeof Tree.DirectoryTree>;
 const PATH_SYNC_PARTIAL_CHILD_THRESHOLD = 40;
+const BASE_DIRECTORY_KEY_PREFIX = 'base::';
+const SYSTEM_DIRECTORY_KEY_PREFIX = 'system::';
+
+function buildBaseDirectoryKey(path: string): string {
+  return `${BASE_DIRECTORY_KEY_PREFIX}${path}`;
+}
+
+function buildSystemDirectoryKey(path: string): string {
+  return `${SYSTEM_DIRECTORY_KEY_PREFIX}${path}`;
+}
+
+function decodeBrowsePathFromTreeKey(key: string): string {
+  if (key.startsWith(BASE_DIRECTORY_KEY_PREFIX)) {
+    return key.substring(BASE_DIRECTORY_KEY_PREFIX.length);
+  }
+  if (key.startsWith(SYSTEM_DIRECTORY_KEY_PREFIX)) {
+    return key.substring(SYSTEM_DIRECTORY_KEY_PREFIX.length);
+  }
+  return key;
+}
+
+function dedupeNodesByCanonicalKey(nodes: TreeDataNode[]): TreeDataNode[] {
+  const seen = new Set<string>();
+  const deduped: TreeDataNode[] = [];
+  for (const node of nodes) {
+    const key = String(node.key);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(node);
+  }
+  return deduped;
+}
 
 // API 응답(FileNode)을 Ant Design Tree가 요구하는 형식(TreeDataNode)으로 변환합니다.
 const convertToFileTreeData = (nodes: FileNode[]): TreeDataNode[] => {
   if (!nodes) return [];
 
-  return nodes
+  return dedupeNodesByCanonicalKey(nodes
     .filter(node => node.isDir) // 폴더만 필터링합니다.
     .map(node => ({
       title: node.name,
-      key: node.path,
+      key: buildBaseDirectoryKey(node.path),
       isLeaf: false, 
-    }));
+    })));
 };
 
 interface FolderTreeProps {
@@ -40,34 +74,34 @@ interface FolderTreeProps {
   bypassSameSelectionGuard?: boolean;
 }
 
-function resolveTargetKey(
+function resolveTargetKeys(
   target: TreeInvalidationTarget,
   spaces: Space[],
   rootPath?: string,
   showBaseDirectories?: boolean
-): string | null {
+): string[] {
   if (showBaseDirectories) {
-    return target.path;
+    return [buildBaseDirectoryKey(target.path), buildSystemDirectoryKey(target.path)];
   }
 
   if (rootPath) {
-    return target.path;
+    return [target.path];
   }
 
   if (!target.spaceId) {
-    return null;
+    return [];
   }
 
   const space = spaces.find((item) => item.id === target.spaceId);
   if (!space) {
-    return null;
+    return [];
   }
 
   if (!target.path) {
-    return `space-${space.id}`;
+    return [`space-${space.id}`];
   }
 
-  return `space-${space.id}::${target.path}`;
+  return [`space-${space.id}::${target.path}`];
 }
 
 function findNodeByKey(list: TreeDataNode[], key: React.Key): TreeDataNode | null {
@@ -313,8 +347,8 @@ const FolderTree: React.FC<FolderTreeProps> = ({
           }
           contents = await fetchSpaceDirectoryContents(spaceId, path);
         } else {
-          path = keyStr;
-          contents = await fetchDirectoryContents(path, showBaseDirectories);
+          path = decodeBrowsePathFromTreeKey(keyStr);
+          contents = await fetchDirectoryContents(path);
         }
 
         const directoryNodes = (contents ?? [])
@@ -336,12 +370,16 @@ const FolderTree: React.FC<FolderTreeProps> = ({
           partialLoadedKeysRef.current.delete(keyStr);
         }
 
-        const directoryChildren = effectiveNodes
+        const directoryChildren = dedupeNodesByCanonicalKey(effectiveNodes
           .map((node) => ({
             title: node.name,
-            key: spacePrefix ? `${spacePrefix}::${node.path}` : node.path,
+            key: spacePrefix
+              ? `${spacePrefix}::${node.path}`
+              : showBaseDirectories
+                ? buildSystemDirectoryKey(node.path)
+                : node.path,
             isLeaf: false,
-          }));
+          })));
         setTreeData((origin) => updateTreeData(origin, key, directoryChildren));
         setLoadedKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
       } catch {
@@ -440,7 +478,7 @@ const FolderTree: React.FC<FolderTreeProps> = ({
 
     const targetKeySet = new Set(
       treeInvalidationTargets
-        .map((target) => resolveTargetKey(target, spaces, rootPath, showBaseDirectories))
+        .flatMap((target) => resolveTargetKeys(target, spaces, rootPath, showBaseDirectories))
         .filter((target): target is string => Boolean(target))
     );
 
@@ -570,8 +608,9 @@ const FolderTree: React.FC<FolderTreeProps> = ({
           }
         }
       } else {
-        if (bypassSameSelectionGuard || !isSameSelection(key)) {
-          onSelect(key);
+        const nextPath = decodeBrowsePathFromTreeKey(key);
+        if (bypassSameSelectionGuard || !isSameSelection(nextPath)) {
+          onSelect(nextPath);
         }
       }
     }

--- a/apps/frontend/src/features/browse/hooks/useBrowseApi.test.ts
+++ b/apps/frontend/src/features/browse/hooks/useBrowseApi.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBrowseApi } from './useBrowseApi';
+
+const h = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiFetch: h.apiFetch,
+}));
+
+vi.mock('@/api/error', () => ({
+  toApiError: vi.fn(async (_response: Response, fallbackErrorMessage: string) => new Error(fallbackErrorMessage)),
+}));
+
+function okJsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('useBrowseApi endpoint boundaries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.apiFetch.mockResolvedValue(okJsonResponse([]));
+  });
+
+  it('uses system browse endpoints for base directories and system path listing', async () => {
+    const { result } = renderHook(() => useBrowseApi());
+
+    await act(async () => {
+      await result.current.fetchBaseDirectories();
+      await result.current.fetchDirectoryContents('/dev');
+    });
+
+    expect(h.apiFetch).toHaveBeenNthCalledWith(1, '/api/browse/base-directories');
+    expect(h.apiFetch).toHaveBeenNthCalledWith(2, '/api/browse?path=%2Fdev');
+  });
+
+  it('uses space browse endpoint for space-scoped directory listing', async () => {
+    const { result } = renderHook(() => useBrowseApi());
+
+    await act(async () => {
+      await result.current.fetchSpaceDirectoryContents(17, '/docs');
+    });
+
+    expect(h.apiFetch).toHaveBeenCalledWith('/api/spaces/17/browse?path=%2Fdocs');
+    expect(h.apiFetch).not.toHaveBeenCalledWith('/api/browse?path=%2Fdocs');
+  });
+});

--- a/apps/frontend/src/features/browse/hooks/useBrowseApi.ts
+++ b/apps/frontend/src/features/browse/hooks/useBrowseApi.ts
@@ -30,15 +30,18 @@ export function useBrowseApi() {
   }, []);
 
   const fetchBaseDirectories = useCallback(async () => {
+    // System browse root candidates for Space creation flow.
     return await fetchData('/api/browse/base-directories', t('browseApi.loadBaseDirectoriesFailed'));
   }, [fetchData, t]);
 
-  const fetchDirectoryContents = useCallback(async (path: string, systemMode = false) => {
-    const url = `/api/browse?path=${encodeURIComponent(path)}${systemMode ? '&system=true' : ''}`;
+  const fetchDirectoryContents = useCallback(async (path: string) => {
+    // System browse endpoint. Not for space-scoped browsing.
+    const url = `/api/browse?path=${encodeURIComponent(path)}`;
     return await fetchData(url, t('browseApi.loadDirectoriesFailed'));
   }, [fetchData, t]);
 
   const fetchSpaceDirectoryContents = useCallback(async (spaceId: number, relativePath: string) => {
+    // Space-scoped browsing endpoint for main explorer flow.
     const url = `/api/spaces/${spaceId}/browse?path=${encodeURIComponent(relativePath)}`;
     return await fetchData(url, t('browseApi.loadSpaceDirectoriesFailed'));
   }, [fetchData, t]);

--- a/apps/frontend/src/stores/browseStore.ts
+++ b/apps/frontend/src/stores/browseStore.ts
@@ -66,11 +66,11 @@ export const useBrowseStore = create<BrowseStore>((set) => ({
     });
   },
 
-  // Space 등록 모달 전용 — Space 외부 시스템 탐색에서만 사용
+  // Space 등록 모달 전용 — 시스템 디렉터리 탐색에서만 사용
   fetchSystemContents: async (path: string) => {
     set({ isLoading: true, error: null });
     try {
-      const url = `/api/browse?path=${encodeURIComponent(path)}&system=true`;
+      const url = `/api/browse?path=${encodeURIComponent(path)}`;
       const response = await apiFetch(url);
       if (!response.ok) {
         throw await toApiError(response, i18n.t('storeErrors.loadDirectoryFailed'));

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -162,3 +162,14 @@ rg "event=error\\.updater\\." logs/updater.log
 - 터미널에서 현재 상태를 빠르게 확인한다. (부팅/재시작/종료, WARN/ERROR/FATAL)
 - 상세 원인 분석이나 자동화 필터링은 파일 로그(`app.log`, `access.log`, `updater.log`)에서 수행한다.
 - `http.access`는 터미널에 출력되지 않으므로, 요청 단위 추적은 반드시 `logs/access.log`를 사용한다.
+
+## Browse API 역할 경계
+
+- `/api/browse/base-directories`, `/api/browse?path=...`
+  - 목적: Space 생성 모달에서 시스템 디렉토리 탐색
+  - 권한: `space.write` 필요
+- `/api/spaces/{id}/browse?path=...`
+  - 목적: 선택된 Space 내부 디렉토리 탐색(일반 파일 브라우저)
+  - 권한: Space 멤버십 기반 `read/write` 권한 검증
+
+정책적으로 `/api/browse`는 시스템 탐색 전용이며, Space 내부 탐색 대체 경로로 사용하지 않는다.


### PR DESCRIPTION
## 요약
### 문제
- `/api/browse`가 과거 `system=true` 분기와 함께 동작하면서 권한 경계가 흐려질 수 있었습니다.
- Space 생성 모달 트리에서 base 루트와 lazy child가 동일 path key를 공유해 반복 토글 시 중복 노드 회귀 위험이 있었습니다.

### 해결
- `/api/browse`, `/api/browse/base-directories` 권한을 `space.write`로 고정하고 회귀 테스트를 추가했습니다.
- `/api/browse`를 시스템 탐색 전용으로 명확화하고, Space 내부 탐색은 `/api/spaces/{id}/browse` 경계로 고정했습니다.
- FolderTree key를 `base::`, `system::` 스코프로 분리하고 선택 경로 decode/dedupe 로직을 추가했습니다.
- 경계 정책을 `docs/backend.md`에 문서화했습니다.

### 기대 효과
- 시스템 탐색/Space 탐색 API 경계가 코드·테스트·문서에서 동시에 고정됩니다.
- Space 생성 트리 반복 확장/축소 시 key 충돌로 인한 노드 누적을 방지합니다.

## 관련 이슈
- Closes #173

## 변경 사항
- Backend
  - `apps/backend/internal/auth/permissions.go`
  - `apps/backend/internal/auth/permissions_test.go`
  - `apps/backend/internal/auth/middleware_test.go`
  - `apps/backend/internal/browse/handler/browse_handler.go`
  - `apps/backend/internal/browse/handler/browse_handler_test.go`
- Frontend
  - `apps/frontend/src/features/browse/components/FolderTree.tsx`
  - `apps/frontend/src/features/browse/components/FolderTree.test.tsx`
  - `apps/frontend/src/features/browse/hooks/useBrowseApi.ts`
  - `apps/frontend/src/features/browse/hooks/useBrowseApi.test.ts`
  - `apps/frontend/src/components/layout/MainLayout/MainSider.test.tsx`
  - `apps/frontend/src/stores/browseStore.ts`
- Docs
  - `docs/backend.md`

## 범위
### In Scope
- 시스템 browse 권한 경계 고정 (`space.write`).
- FolderTree key 스코프 분리 및 선택 경로 복원.
- 프론트/백엔드 회귀 테스트 및 문서 보강.

### Out of Scope
- 감사 로그 기능 (#126)
- Space 내부 browse API 계약 변경

## 테스트/검증
- `pnpm -C apps/frontend lint` PASS
- `pnpm -C apps/frontend typecheck` PASS
- `pnpm -C apps/frontend test` PASS (`6 files, 21 tests`)
- `cd apps/backend && go test ./...` PASS

## 리스크 및 대응
- 잠재 회귀: 트리 key 스코프 변경으로 선택/확장 동기화가 틀어질 수 있음.
- 대응: FolderTree 반복 토글/선택 경로 복원 테스트를 추가해 회귀를 고정.
- 롤백: 본 PR revert 시 기존 key/endpoint 분기로 즉시 복귀 가능.

## 리뷰 가이드
- 우선 확인 파일
  - `apps/frontend/src/features/browse/components/FolderTree.tsx`
  - `apps/backend/internal/auth/permissions.go`
  - `apps/backend/internal/browse/handler/browse_handler.go`
  - `apps/frontend/src/features/browse/components/FolderTree.test.tsx`
  - `apps/backend/internal/auth/middleware_test.go`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [ ] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #173`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음