### PR TITLE
chore: smb-core 외부 RC pin 전환과 배포 게이트 정렬

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,6 @@ jobs:
         run: go test ./...
         working-directory: apps/backend
 
-      - name: Run SMB core boundary guard
-        run: ./scripts/check-smbcore-boundary.sh
-        working-directory: apps/backend
-
-      - name: Run SMB compatibility baseline
-        run: ./scripts/check-smb-compat-baseline.sh
-        working-directory: apps/backend
-
-      - name: Run SMB integration smoke
-        run: go test -tags integration ./internal/smb -run TestSMB
+      - name: Run SMB publication gates
+        run: ./scripts/check-smb-publication-gates.sh
         working-directory: apps/backend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
         run: go test ./...
         working-directory: apps/backend
 
+      - name: Run SMB publication gates
+        run: ./scripts/check-smb-publication-gates.sh
+        working-directory: apps/backend
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/apps/backend/go.mod
+++ b/apps/backend/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/lteawoo/smb-core v1.0.0-rc.1
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect

--- a/apps/backend/go.sum
+++ b/apps/backend/go.sum
@@ -45,6 +45,8 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
+github.com/lteawoo/smb-core v1.0.0-rc.1 h1:KFiKdyk4iYAbY/1cnL7tSDoF1NRQGl/weD/XR76P46A=
+github.com/lteawoo/smb-core v1.0.0-rc.1/go.mod h1:MHb6w6Q7Cp8LKpkNEzKBb9WB+lW+LaklQOqjmX8y6n8=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/apps/backend/internal/smb/adapter.go
+++ b/apps/backend/internal/smb/adapter.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/lteawoo/smb-core"
 	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/space"
-	"taeu.kr/cohesion/pkg/smbcore"
 )
 
 type coreAuthenticator struct {

--- a/apps/backend/internal/smb/adapter_test.go
+++ b/apps/backend/internal/smb/adapter_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/lteawoo/smb-core"
 	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/space"
-	"taeu.kr/cohesion/pkg/smbcore"
 )
 
 func TestCoreAuthenticator_Authenticate(t *testing.T) {

--- a/apps/backend/internal/smb/guard.go
+++ b/apps/backend/internal/smb/guard.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/lteawoo/smb-core"
 	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/space"
-	"taeu.kr/cohesion/pkg/smbcore"
 )
 
 type Guard struct {

--- a/apps/backend/internal/smb/service.go
+++ b/apps/backend/internal/smb/service.go
@@ -7,11 +7,11 @@ import (
 	"net"
 	"sync"
 
+	"github.com/lteawoo/smb-core"
 	"github.com/rs/zerolog/log"
 	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/config"
 	"taeu.kr/cohesion/internal/space"
-	"taeu.kr/cohesion/pkg/smbcore"
 )
 
 type Service struct {

--- a/apps/backend/scripts/check-smb-compat-baseline.sh
+++ b/apps/backend/scripts/check-smb-compat-baseline.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 # Dialect bounds + deny taxonomy(readonly/permission/boundary) + rollback baseline
-go test ./pkg/smbcore -run 'TestHandleConn_EnforcesDialectBoundsAndRejectsSMB1|TestHandleConn_ReadonlyPhaseDenied_EmitsTelemetryReason|TestHandleConn_WriteFull_ManagePermissionDeniedReason|TestHandleConn_WriteFull_ManageOpsAndBoundaryReason|TestHandleConn_RollbackToReadonly_DeniesNewWriteRequests'
+module_target="./pkg/smbcore"
+if go list github.com/lteawoo/smb-core >/dev/null 2>&1; then
+  module_target="github.com/lteawoo/smb-core"
+fi
+go test "$module_target" -run 'TestHandleConn_EnforcesDialectBoundsAndRejectsSMB1|TestHandleConn_ReadonlyPhaseDenied_EmitsTelemetryReason|TestHandleConn_WriteFull_ManagePermissionDeniedReason|TestHandleConn_WriteFull_ManageOpsAndBoundaryReason|TestHandleConn_RollbackToReadonly_DeniesNewWriteRequests|TestEngineCheckUsability'
 
 # SMB readiness semantics baseline (service/state surface)
 go test ./internal/smb -run 'TestService_StartStop_Disabled|TestService_StartFailure_UpdatesReadiness|TestService_StartStop_Enabled'

--- a/apps/backend/scripts/check-smb-publication-gates.sh
+++ b/apps/backend/scripts/check-smb-publication-gates.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unified publication gate set for smbcore external release readiness.
+./scripts/check-smbcore-boundary.sh
+./scripts/check-smb-compat-baseline.sh
+go test -tags integration ./internal/smb -run TestSMB
+
+echo "[smb-publication-gates] ok"

--- a/apps/backend/scripts/check-smbcore-boundary.sh
+++ b/apps/backend/scripts/check-smbcore-boundary.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-imports="$(go list -f '{{ join .Imports "\n" }}' ./pkg/smbcore)"
+module_target="./pkg/smbcore"
+if go list github.com/lteawoo/smb-core >/dev/null 2>&1; then
+  module_target="github.com/lteawoo/smb-core"
+fi
+imports="$(go list -f '{{ join .Imports "\n" }}' "$module_target")"
 
 # Block direct imports of Cohesion domain packages and their subpackages.
 disallowed='^taeu\.kr/cohesion/internal/(account|space|config)(/|$)'
 if printf '%s\n' "$imports" | rg -q "$disallowed"; then
-  echo "[smbcore-boundary] disallowed Cohesion domain import detected in pkg/smbcore"
+  echo "[smbcore-boundary] disallowed Cohesion domain import detected in smbcore module"
   printf '%s\n' "$imports" | rg "$disallowed" || true
   exit 1
 fi

--- a/docs/releases/smbcore/evidence-template.md
+++ b/docs/releases/smbcore/evidence-template.md
@@ -1,0 +1,60 @@
+# SMBCore Release Evidence Template
+
+이 문서는 `smbcore` 릴리즈 후보(`rc`/stable)별 게이트 증빙 템플릿이다.
+
+## 1. Release Metadata
+
+- Version:
+- Tag:
+- Commit SHA:
+- Date (UTC):
+- Owner:
+
+## 2. Boundary Guard
+
+- Command:
+  - `cd apps/backend && ./scripts/check-smbcore-boundary.sh`
+- Result:
+  - pass/fail:
+  - log summary:
+
+## 3. Compatibility Baseline
+
+- Command:
+  - `cd apps/backend && ./scripts/check-smb-compat-baseline.sh`
+- Scope confirmation:
+  - dialect bounds (`2.1`~`3.1.1`, SMB1 reject)
+  - rollout phase deny semantics (`readonly_phase_denied`)
+  - deny taxonomy (`permission_denied`, `path_boundary_violation`)
+  - readiness semantics (`internal/smb`, `internal/status`)
+- Result:
+  - pass/fail:
+  - log summary:
+
+## 4. SMB Integration Smoke
+
+- Command:
+  - `cd apps/backend && go test -tags integration ./internal/smb -run TestSMB`
+- Result:
+  - pass/fail:
+  - log summary:
+
+## 5. Unified Publication Gate
+
+- Command:
+  - `cd apps/backend && ./scripts/check-smb-publication-gates.sh`
+- Result:
+  - pass/fail:
+  - log summary:
+
+## 6. Migration / Rollback References
+
+- Migration guide link:
+- Rollback guide link:
+- Parity checklist result link:
+
+## 7. Reviewer Sign-off
+
+- Reviewer:
+- Approval date:
+- Notes:

--- a/docs/releases/smbcore/external-transition/v0.0.0-bootstrap/evidence.md
+++ b/docs/releases/smbcore/external-transition/v0.0.0-bootstrap/evidence.md
@@ -1,0 +1,58 @@
+# External Transition Evidence (v0.0.0-bootstrap)
+
+## Metadata
+
+- Date (UTC): 2026-03-04
+- External repo: `https://github.com/lteawoo/smb-core.git`
+- External module: `github.com/lteawoo/smb-core`
+- Cohesion branch context: local transition workspace
+
+## A. External Repo Bootstrap Validation
+
+Executed in `/Users/twlee/projects/smb-core`:
+
+```bash
+go mod tidy
+go test ./...
+./scripts/check-smb-publication-gates.sh
+```
+
+Result:
+- `go test ./...` pass
+- boundary/compat/integration/publication gates pass
+
+## B. Cohesion Transition Validation (external module wiring)
+
+Executed in `apps/backend`:
+
+```bash
+./scripts/check-smb-publication-gates.sh
+go test ./...
+```
+
+Result:
+- `smbcore-boundary` pass (external module target)
+- `smb-compat-baseline` pass
+- `smb-publication-gates` pass
+- `go test ./...` pass
+
+## C. Rollback Rehearsal Validation
+
+Executed in sandbox copy `/tmp/cohesion-smbcore-rollback-sandbox`:
+
+```bash
+# import/go.mod rollback to in-repo smbcore
+./scripts/check-smb-publication-gates.sh
+go test ./...
+```
+
+Result:
+- `smbcore-boundary` pass (in-repo fallback target)
+- `smb-compat-baseline` pass
+- `smb-publication-gates` pass
+- `go test ./...` pass
+
+## D. Notes
+
+- Current Cohesion wiring is transition mode with pinned external dependency and local replace for bootstrap.
+- Before production cutover, remove local replace and pin RC/stable tag.

--- a/docs/releases/smbcore/external-transition/v1.0.0-rc.1/evidence.md
+++ b/docs/releases/smbcore/external-transition/v1.0.0-rc.1/evidence.md
@@ -1,0 +1,59 @@
+# External Transition Evidence (v1.0.0-rc.1)
+
+## Metadata
+
+- Date (UTC): 2026-03-04
+- External repo: `https://github.com/lteawoo/smb-core.git`
+- External module: `github.com/lteawoo/smb-core`
+- Resolved version: `v1.0.0-rc.1`
+
+## A. External Repo Validation
+
+Executed in `/Users/twlee/projects/smb-core`:
+
+```bash
+go test ./...
+./scripts/check-smb-publication-gates.sh
+```
+
+Result:
+- `go test ./...` pass
+- boundary/compat/integration/publication gates pass
+
+## B. Cohesion Transition Validation (pinned external module)
+
+Executed in `apps/backend`:
+
+```bash
+./scripts/check-smb-publication-gates.sh
+go test ./...
+go build ./...
+```
+
+Result:
+- `smbcore-boundary` pass
+- `smb-compat-baseline` pass
+- `smb-publication-gates` pass
+- `go test ./...` pass
+- `go build ./...` pass
+
+## C. Rollback Rehearsal Validation
+
+Executed in sandbox copy `/tmp/cohesion-smbcore-rollback-sandbox`:
+
+```bash
+# import/go.mod rollback to in-repo smbcore
+./scripts/check-smb-publication-gates.sh
+go test ./...
+```
+
+Result:
+- `smbcore-boundary` pass (in-repo fallback target)
+- `smb-compat-baseline` pass
+- `smb-publication-gates` pass
+- `go test ./...` pass
+
+## D. Notes
+
+- Cohesion `apps/backend/go.mod` pins `github.com/lteawoo/smb-core v1.0.0-rc.1`.
+- Committed shared path has no local `replace` entry.

--- a/docs/smbcore-external-transition.md
+++ b/docs/smbcore-external-transition.md
@@ -1,0 +1,67 @@
+# SMBCore External Module Transition Runbook
+
+## Canonical Targets
+
+- External repository: `https://github.com/lteawoo/smb-core.git`
+- External module path: `github.com/lteawoo/smb-core`
+- Transition working branch: `chore/smbcore-external-v1.0.0-rc.1`
+
+## 1. Transition Procedure (Cohesion -> external module)
+
+1. Create transition branch.
+2. Switch imports from `taeu.kr/cohesion/pkg/smbcore` to `github.com/lteawoo/smb-core`.
+3. Pin module version in `apps/backend/go.mod` to released tag (`v1.0.0-rc.1` or newer).
+4. Do not commit local `replace` wiring in shared branch/CI path.
+5. Only use temporary local `replace` for private sandbox rehearsal.
+
+## 2. Parity Gate Commands
+
+```bash
+cd apps/backend
+./scripts/check-smb-publication-gates.sh
+go test ./...
+```
+
+Evidence path:
+- `docs/releases/smbcore/external-transition/<version>/evidence.md`
+
+## 3. Deterministic Rollback Checkpoint
+
+Known-good rollback checkpoint MUST contain:
+- Previous dependency wiring (`taeu.kr/cohesion/pkg/smbcore` imports)
+- `apps/backend/go.mod` without `github.com/lteawoo/smb-core` dependency/replace
+- Passing gate evidence for rollback snapshot
+
+Restore commands:
+
+```bash
+# 1) Revert import wiring to in-repo smbcore package
+rg -l 'github.com/lteawoo/smb-core' apps/backend/internal/smb | \
+  xargs -I{} perl -0pi -e 's#"github.com/lteawoo/smb-core"#"taeu.kr/cohesion/pkg/smbcore"#g' {}
+
+# 2) Remove external module wiring
+cd apps/backend
+go mod edit -droprequire=github.com/lteawoo/smb-core
+go mod edit -dropreplace=github.com/lteawoo/smb-core
+go mod tidy
+
+# 3) Re-run parity gates
+./scripts/check-smb-publication-gates.sh
+go test ./...
+```
+
+## 4. Rollback Rehearsal Rule
+
+Before source-of-truth cutover, maintainers MUST execute at least one rollback rehearsal on a sandbox/worktree and archive evidence.
+
+## 5. Transition Window Exit Criteria
+
+All criteria MUST be satisfied:
+
+- [ ] External repo CI green (`go test ./...`, publication gates)
+- [ ] Cohesion transition parity gates green with pinned external module
+- [ ] Rollback rehearsal completed and evidence archived
+- [ ] First RC tag exists in `smb-core`
+- [ ] Release evidence reviewed/approved
+
+When all criteria are met, mark `github.com/lteawoo/smb-core` as SMB core source-of-truth and freeze ad-hoc dual-source edits.

--- a/docs/smbcore-publishing-v1.md
+++ b/docs/smbcore-publishing-v1.md
@@ -1,0 +1,134 @@
+# smbcore v1 Publication Guide
+
+## 1) v1 Public API Surface
+
+`apps/backend/pkg/smbcore`에서 아래 항목을 v1 호환 계약으로 취급한다.
+
+- 타입/상수:
+  - `Dialect`, `Dialect210|300|302|311`
+  - `Permission`, `PermissionRead|Write|Manage`
+  - `RolloutPhase`, `RolloutPhaseReadOnly|WriteSafe|WriteFull`
+  - `DenyReasonReadonlyPhaseDenied|PermissionDenied|PathBoundary`
+  - `ErrPermissionDenied|ErrPathBoundary|ErrReadonlyPhaseDenied`
+  - `ErrRuntimeNotImplemented|ErrRuntimeDependenciesMissing|ErrInvalidDialectBounds`
+- 인터페이스:
+  - `Authenticator`, `Authorizer`, `FileSystem`, `Telemetry`, `Runtime`
+- 구조체/생성자:
+  - `DirEntry`, `Event`, `Config`, `Engine`, `NewEngine(...)`
+- 메서드:
+  - `Config.Validate()`
+  - `Engine.HandleConn(...)`
+  - `Engine.Supports(...)`
+  - `Engine.IsReadOnly()`
+  - `Engine.Phase()`
+  - `Engine.CheckUsability(...)`
+
+다음은 v1 호환 계약에서 제외한다.
+
+- `pkg/smbcore`의 비공개 심볼(소문자 시작 함수/구조체/상수)
+- 테스트 전용 헬퍼/테스트 빌드 경로
+
+## 2) Semantic Versioning Policy
+
+- 첫 공개 안정 버전은 `v1.0.0`으로 발행한다.
+- 프리릴리즈는 `v1.0.0-rc.N` 형식을 사용한다.
+- `PATCH` (`v1.0.x`):
+  - 공개 API 시그니처/의미를 깨지 않는 버그 수정
+  - 동작 안정성 개선, 문서 수정
+- `MINOR` (`v1.x.0`):
+  - 하위 호환을 유지하는 공개 API 추가
+  - opt-in 기능 확장
+- `MAJOR` (`v2.0.0+`):
+  - 공개 API 제거/시그니처 변경/호환 불가 의미 변경
+  - 기본 동작 계약(예: deny taxonomy, readiness 계약)의 비호환 변경
+
+브레이킹 변경은 릴리즈 노트에 반드시 아래를 포함한다.
+
+- 변경된 API 목록
+- 영향 범위
+- 이전 버전 대비 마이그레이션 절차
+
+## 3) Release Notes / Migration Minimum
+
+모든 릴리즈 노트는 최소 아래 섹션을 포함한다.
+
+- `Summary`
+- `Compatibility`
+- `Changes`
+- `Migration` (필요 시)
+- `Rollback` (이전 버전 복귀 절차)
+
+브레이킹 릴리즈의 `Migration`에는 아래가 필수다.
+
+- 기존 호출 예시 -> 신규 호출 예시
+- 설정/정책 차이
+- 검증 명령(게이트 스크립트 포함)
+
+## 4) Publication Gates and Evidence Format
+
+발행 승인 전 아래 명령이 모두 통과해야 한다.
+
+```bash
+cd apps/backend && ./scripts/check-smb-publication-gates.sh
+```
+
+게이트 구성:
+
+- `check-smbcore-boundary.sh`: 경계 누수(import) 검증
+- `check-smb-compat-baseline.sh`: dialect/phase/taxonomy/readiness baseline
+- `go test -tags integration ./internal/smb -run TestSMB`: SMB integration smoke
+
+증빙은 `docs/releases/smbcore/<version>/evidence.md`에 보관한다.
+포맷은 [evidence-template.md](/Users/twlee/projects/Cohesion/docs/releases/smbcore/evidence-template.md) 기준을 사용한다.
+
+## 5) Cohesion External Module Transition Procedure
+
+1. 전환 브랜치 생성 (`chore/smbcore-external-<version>`).
+2. import 경로를 in-repo 경로에서 외부 모듈 경로로 일괄 전환:
+   - `taeu.kr/cohesion/pkg/smbcore` -> `github.com/lteawoo/smb-core`
+3. 버전 고정:
+   - `cd apps/backend && go get github.com/lteawoo/smb-core@<version>`
+   - `cd apps/backend && go mod tidy`
+4. 게이트 검증:
+   - `cd apps/backend && ./scripts/check-smb-publication-gates.sh`
+   - `cd apps/backend && go test ./...`
+5. 전환 증빙을 `docs/releases/smbcore/<version>/evidence.md`에 기록.
+
+## 6) Deterministic Rollback Procedure
+
+1. import 경로를 이전 in-repo 경로로 복구:
+   - `github.com/lteawoo/smb-core` -> `taeu.kr/cohesion/pkg/smbcore`
+2. `go.mod`/`go.sum`을 이전 known-good 커밋 기준으로 복구.
+3. 검증 재실행:
+   - `cd apps/backend && ./scripts/check-smb-publication-gates.sh`
+   - `cd apps/backend && go test ./...`
+4. rollback 증빙을 동일 evidence 문서에 추가 기록.
+
+## 7) Parity Verification Checklist (Post-Transition / Post-Rollback)
+
+- [ ] boundary guard 통과
+- [ ] compatibility baseline 통과
+- [ ] integration smoke 통과
+- [ ] `go test ./...` 통과
+- [ ] status/readiness 주요 시나리오 회귀 없음 확인
+- [ ] deny taxonomy(`readonly_phase_denied`, `permission_denied`, `path_boundary_violation`) 회귀 없음 확인
+
+## 8) Tag and Version Policy
+
+- RC 태그: `smbcore-v1.0.0-rc.N`
+- 안정 태그: `smbcore-v1.0.0`
+- 이후 릴리즈:
+  - patch: `smbcore-v1.0.X`
+  - minor: `smbcore-v1.X.0`
+- major 전환 시:
+  - breaking migration 가이드 필수
+  - 최소 1회 RC 라운드 필수
+
+## 9) Publication Readiness Checklist
+
+- [ ] public API surface 최신화
+- [ ] semver 분류 검토 완료
+- [ ] 게이트 스크립트 통과 증빙 첨부
+- [ ] migration/rollback 문서 점검 완료
+- [ ] release notes 초안 작성 완료
+- [ ] evidence 문서 링크가 릴리즈 노트에 연결됨


### PR DESCRIPTION
## 요약
### 문제
- 로컬 `replace` 의존 경로는 CI/공유 환경 재현성을 저해할 수 있습니다.
- SMB 배포 검증 게이트가 워크플로 단계마다 분산돼 릴리즈 기준 일관성이 낮았습니다.

### 해결
- Cohesion backend 의존성을 `github.com/lteawoo/smb-core v1.0.0-rc.1`로 pin하고 `replace`를 제거했습니다.
- CI/release에서 공통으로 `check-smb-publication-gates.sh`를 실행하도록 통합했습니다.
- boundary/compat/integration 검증 경로를 외부 모듈 전환 흐름에 맞춰 정렬하고 문서/증빙을 추가했습니다.

### 기대 효과
- 로컬 경로 의존 없이 동일한 버전으로 재현 가능한 빌드/테스트 보장
- 릴리즈 게이트 기준 단일화로 운영 리스크 감소

## 관련 이슈
- Closes #179
- Related #178

## 변경 사항
- 의존성/코드
  - `apps/backend/go.mod`, `go.sum`: `github.com/lteawoo/smb-core v1.0.0-rc.1` pin
  - `apps/backend/internal/smb/*`: in-repo `pkg/smbcore` import -> 외부 모듈 import 전환
- 게이트/CI
  - `apps/backend/scripts/check-smb-publication-gates.sh` 추가
  - `.github/workflows/ci.yml`, `.github/workflows/release.yml`에서 publication gate 통합 실행
  - `apps/backend/scripts/check-smbcore-boundary.sh`, `check-smb-compat-baseline.sh` external/in-repo fallback 기준 보강
- 문서/증빙
  - `docs/smbcore-publishing-v1.md`
  - `docs/smbcore-external-transition.md`
  - `docs/releases/smbcore/evidence-template.md`
  - `docs/releases/smbcore/external-transition/v0.0.0-bootstrap/evidence.md`
  - `docs/releases/smbcore/external-transition/v1.0.0-rc.1/evidence.md`

## 범위
### In Scope
- `smb-core` 외부 모듈 RC pin 전환
- publication gate 단일 실행 경로 정렬
- 문서/evidence 보강

### Out of Scope
- SMB 프로토콜 신규 기능 추가
- `smb-core` API 계약 변경

## 테스트/검증
- `cd apps/backend && ./scripts/check-smb-publication-gates.sh` PASS
- `cd apps/backend && go test ./...` PASS
- `cd apps/backend && go build ./...` PASS

## 리스크 및 대응
- 리스크: 외부 모듈 버전 불일치/미발행 태그 참조 시 빌드 실패
- 대응: `v1.0.0-rc.1` 고정 + release evidence에 검증 결과 보관
- 롤백: import를 `taeu.kr/cohesion/pkg/smbcore`로 복구하고 `go.mod` external require 제거 후 게이트 재실행

## 리뷰 가이드
1. `apps/backend/go.mod`
2. `apps/backend/scripts/check-smb-publication-gates.sh`
3. `.github/workflows/ci.yml`
4. `.github/workflows/release.yml`
5. `docs/smbcore-external-transition.md`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [ ] 릴리즈 카테고리 라벨 확인 (`chore` 권장)
- [x] 관련 이슈 링크 확인 (`Closes`/`Related`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음