### PR TITLE
chore: smb-core 의존성을 v1.0.0으로 고정

### DIFF
--- a/apps/backend/go.mod
+++ b/apps/backend/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/lteawoo/smb-core v1.0.0-rc.1
+	github.com/lteawoo/smb-core v1.0.0
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect

--- a/apps/backend/go.sum
+++ b/apps/backend/go.sum
@@ -45,8 +45,8 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/lteawoo/smb-core v1.0.0-rc.1 h1:KFiKdyk4iYAbY/1cnL7tSDoF1NRQGl/weD/XR76P46A=
-github.com/lteawoo/smb-core v1.0.0-rc.1/go.mod h1:MHb6w6Q7Cp8LKpkNEzKBb9WB+lW+LaklQOqjmX8y6n8=
+github.com/lteawoo/smb-core v1.0.0 h1:9aEIM4DhLLOeaaSZNJxUz1UXjqJ/9Xfm032knORcejQ=
+github.com/lteawoo/smb-core v1.0.0/go.mod h1:MHb6w6Q7Cp8LKpkNEzKBb9WB+lW+LaklQOqjmX8y6n8=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=


### PR DESCRIPTION
## 요약
### 문제
- Cohesion backend가 `smb-core v1.0.0-rc.1`을 pin 중이라 안정 태그 발행 이후 기준선이 RC에 머물러 있었습니다.

### 해결
- `apps/backend/go.mod`, `go.sum`을 `github.com/lteawoo/smb-core v1.0.0`으로 갱신했습니다.

### 기대 효과
- Cohesion 의존 버전을 안정 태그 기준으로 고정해 운영/검증 기준선을 단순화합니다.

## 관련 이슈
- Closes #181

## 변경 사항
- `apps/backend/go.mod`
- `apps/backend/go.sum`

## 범위
### In Scope
- Cohesion backend의 `smb-core` 버전 상향 (`v1.0.0-rc.1` -> `v1.0.0`)

### Out of Scope
- SMB 기능/동작 변경
- API 계약 변경

## 테스트/검증
- `cd apps/backend && ./scripts/check-smb-publication-gates.sh` PASS
- `cd apps/backend && go test ./...` PASS
- `cd apps/backend && go build ./...` PASS

## 리스크 및 대응
- 리스크: 외부 모듈 버전 전환에 따른 미세 회귀
- 대응: publication gates + 전체 테스트/빌드 통과 확인
- 롤백: `go get github.com/lteawoo/smb-core@v1.0.0-rc.1` 후 동일 검증 재실행

## 리뷰 가이드
1. `apps/backend/go.mod`
2. `apps/backend/go.sum`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [ ] 릴리즈 카테고리 라벨 확인 (`chore` 권장)
- [x] 관련 이슈 링크 확인
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 브레이킹 변경 없음