### PR TITLE
fix: startup secret prewarm 오류 전파와 source 분류 정합화

### DIFF
--- a/apps/backend/internal/account/service.go
+++ b/apps/backend/internal/account/service.go
@@ -10,7 +10,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 
@@ -39,17 +41,20 @@ type Storer interface {
 	ReplaceRolePermissionKeys(ctx context.Context, roleName string, permissionKeys []string) error
 	UpsertSMBCredential(ctx context.Context, userID int64, smbMaterial string, materialVersion int) error
 	GetSMBCredential(ctx context.Context, userID int64) (*SMBCredential, error)
+	HasAnySMBCredential(ctx context.Context) (bool, error)
 }
 
 const (
-	smbMaterialVersion       = 4
-	legacySMBMaterialVersion = 3
-	defaultSMBMaterialKey    = "cohesion-dev-smb-material-key"
+	smbMaterialVersion = 4
 
 	smbMaterialKeySourceEnv           = "env:COHESION_SMB_MATERIAL_KEY"
-	smbMaterialKeySourceFallback      = "fallback:development-default"
-	smbMaterialKeySourceLegacyJWT     = "legacy:COHESION_JWT_SECRET"
-	smbMaterialKeySourceLegacyDefault = "legacy:development-default"
+	smbMaterialKeySourceFileExisting  = "file:existing"
+	smbMaterialKeySourceFileGenerated = "file:generated"
+
+	smbMaterialKeyPathEnv        = "COHESION_SMB_MATERIAL_KEY_FILE"
+	defaultSMBMaterialKeyFile    = "smb_material_key"
+	smbMaterialKeyDirPermission  = 0o700
+	smbMaterialKeyFilePermission = 0o600
 )
 
 type Service struct {
@@ -59,12 +64,17 @@ type Service struct {
 type smbMaterialSecret struct {
 	value  string
 	source string
-	legacy bool
+}
+
+type SMBMaterialKeyPrewarmResult struct {
+	Source string
+	Path   string
 }
 
 var (
 	ErrInitialSetupCompleted          = errors.New("initial setup already completed")
 	ErrSMBCredentialRecoveryRequired  = errors.New("smb credential recovery required")
+	errSMBMaterialKeyMissing          = errors.New("smb material key missing")
 	requireExplicitSMBMaterialKeyFlag atomic.Bool
 )
 
@@ -77,16 +87,70 @@ func IsSMBMaterialKeyRequired() bool {
 }
 
 func ValidateSMBMaterialKeyConfiguration() error {
-	_, err := resolvePrimarySMBMaterialSecret()
+	_, err := resolvePrimarySMBMaterialSecretWithoutBootstrap()
 	return err
 }
 
 func CurrentSMBMaterialKeySource() string {
-	secret, err := resolvePrimarySMBMaterialSecret()
+	secret, err := resolvePrimarySMBMaterialSecretWithoutBootstrap()
 	if err != nil {
 		return "unavailable"
 	}
 	return secret.source
+}
+
+func (s *Service) ValidateSMBMaterialKeyConfiguration(ctx context.Context) (string, error) {
+	secret, err := s.resolvePrimarySMBMaterialSecret(ctx)
+	if err != nil {
+		return "", err
+	}
+	return secret.source, nil
+}
+
+func (s *Service) PrewarmSMBMaterialKey(ctx context.Context) (SMBMaterialKeyPrewarmResult, error) {
+	if s == nil {
+		return SMBMaterialKeyPrewarmResult{}, errors.New("account service is required")
+	}
+
+	if secret := strings.TrimSpace(os.Getenv("COHESION_SMB_MATERIAL_KEY")); secret != "" {
+		return SMBMaterialKeyPrewarmResult{Source: "env"}, nil
+	}
+
+	path, err := resolveSMBMaterialKeyPath()
+	if err != nil {
+		return SMBMaterialKeyPrewarmResult{}, err
+	}
+
+	secret, exists, err := readSMBMaterialSecretFromFile(path)
+	if err != nil {
+		return SMBMaterialKeyPrewarmResult{}, err
+	}
+	if exists && strings.TrimSpace(secret) != "" {
+		return SMBMaterialKeyPrewarmResult{Source: "file", Path: path}, nil
+	}
+
+	hasCredentials, err := s.hasAnySMBCredential(ctx)
+	if err != nil {
+		return SMBMaterialKeyPrewarmResult{}, fmt.Errorf("check existing smb credentials: %w", err)
+	}
+	if hasCredentials {
+		return SMBMaterialKeyPrewarmResult{}, missingSMBMaterialKeyWithCredentialDataError()
+	}
+
+	generated, err := generateRandomSMBMaterialSecret(48)
+	if err != nil {
+		return SMBMaterialKeyPrewarmResult{}, err
+	}
+	if err := writeSMBMaterialSecretToFile(path, generated); err != nil {
+		return SMBMaterialKeyPrewarmResult{}, err
+	}
+
+	logging.Event(log.Info(), logging.ComponentAuth, "info.smb.material_key_prewarmed").
+		Str("source", smbMaterialKeySourceFileGenerated).
+		Str("path", path).
+		Msg("[SMB] material key prewarmed from generated secret file")
+
+	return SMBMaterialKeyPrewarmResult{Source: "generated", Path: path}, nil
 }
 
 func NewService(store Storer) *Service {
@@ -194,7 +258,7 @@ func (s *Service) CreateUser(ctx context.Context, req *CreateUserRequest) (*User
 	if err != nil {
 		return nil, err
 	}
-	material, err := deriveSMBMaterial(req.Username, req.Password)
+	material, err := s.deriveSMBMaterial(ctx, req.Username, req.Password)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +317,7 @@ func (s *Service) UpdateUser(ctx context.Context, id int64, req *UpdateUserReque
 	}
 
 	if rawPassword != nil {
-		material, err := deriveSMBMaterial(current.Username, *rawPassword)
+		material, err := s.deriveSMBMaterial(ctx, current.Username, *rawPassword)
 		if err != nil {
 			return nil, err
 		}
@@ -330,7 +394,7 @@ func (s *Service) ResolveSMBPassword(ctx context.Context, username string) (stri
 		return "", err
 	}
 
-	password, requiresMigration, err := decodeSMBMaterial(credential.SMBMaterial, credential.MaterialVersion)
+	password, err := s.decodeSMBMaterial(ctx, credential.SMBMaterial, credential.MaterialVersion)
 	if err != nil {
 		logging.Event(log.Warn(), logging.ComponentAuth, "warn.smb.material.decode_failed").
 			Err(err).
@@ -339,23 +403,6 @@ func (s *Service) ResolveSMBPassword(ctx context.Context, username string) (stri
 			Int("material_version", credential.MaterialVersion).
 			Msg("[SMB] failed to decode credential material")
 		return "", wrapSMBCredentialRecoveryError(err)
-	}
-
-	if requiresMigration {
-		if err := s.upsertSMBCredential(ctx, user, password); err != nil {
-			logging.Event(log.Warn(), logging.ComponentAuth, "warn.smb.material.migration_failed").
-				Err(err).
-				Str("username", user.Username).
-				Int64("user_id", user.ID).
-				Int("material_version", credential.MaterialVersion).
-				Msg("[SMB] failed to migrate credential material")
-			return "", wrapSMBCredentialRecoveryError(err)
-		}
-		logging.Event(log.Info(), logging.ComponentAuth, "info.smb.material.migrated").
-			Str("username", user.Username).
-			Int64("user_id", user.ID).
-			Int("previous_material_version", credential.MaterialVersion).
-			Msg("[SMB] credential material migrated to current policy")
 	}
 
 	return password, nil
@@ -564,19 +611,26 @@ func (s *Service) upsertSMBCredential(ctx context.Context, user *User, password 
 		return errors.New("password is required")
 	}
 
-	material, err := deriveSMBMaterial(user.Username, password)
+	material, err := s.deriveSMBMaterial(ctx, user.Username, password)
 	if err != nil {
 		return err
 	}
 	return s.store.UpsertSMBCredential(ctx, user.ID, material, smbMaterialVersion)
 }
 
-func deriveSMBMaterial(username, password string) (string, error) {
+func (s *Service) deriveSMBMaterial(ctx context.Context, username, password string) (string, error) {
 	_ = username
 	if password == "" {
 		return "", errors.New("password is required")
 	}
-	secret, err := resolvePrimarySMBMaterialSecret()
+	return s.encodeSMBMaterial(ctx, password)
+}
+
+func (s *Service) encodeSMBMaterial(ctx context.Context, password string) (string, error) {
+	if password == "" {
+		return "", errors.New("password is required")
+	}
+	secret, err := s.resolvePrimarySMBMaterialSecret(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -593,89 +647,53 @@ func deriveSMBMaterial(username, password string) (string, error) {
 	return "enc:" + base64.StdEncoding.EncodeToString(nonce) + ":" + base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
-func decodeSMBMaterial(material string, version int) (string, bool, error) {
-	switch version {
-	case smbMaterialVersion:
-		return decodeEncryptedSMBMaterial(material)
-	case legacySMBMaterialVersion:
-		password, err := decodeLegacySMBMaterial(material)
-		if err != nil {
-			return "", false, err
-		}
-		return password, true, nil
-	default:
-		return "", false, fmt.Errorf("unsupported smb material version: %d", version)
+func (s *Service) decodeSMBMaterial(ctx context.Context, material string, version int) (string, error) {
+	if version != smbMaterialVersion {
+		return "", fmt.Errorf("unsupported smb material version: %d", version)
 	}
+	return s.decodeEncryptedSMBMaterial(ctx, material)
 }
 
-func decodeLegacySMBMaterial(material string) (string, error) {
+func (s *Service) decodeEncryptedSMBMaterial(ctx context.Context, material string) (string, error) {
 	payload := strings.TrimSpace(material)
-	if !strings.HasPrefix(payload, "plain:") {
+	parts := strings.Split(payload, ":")
+	if len(parts) != 3 || parts[0] != "enc" {
 		return "", errors.New("invalid smb material format")
 	}
 
-	encoded := strings.TrimPrefix(payload, "plain:")
-	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	nonce, err := base64.StdEncoding.DecodeString(parts[1])
 	if err != nil {
-		return "", fmt.Errorf("invalid smb material encoding: %w", err)
+		return "", fmt.Errorf("invalid smb material nonce: %w", err)
 	}
-	password := string(decoded)
+	ciphertext, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid smb material ciphertext: %w", err)
+	}
+
+	secret, err := s.resolvePrimarySMBMaterialSecret(ctx)
+	if err != nil {
+		return "", err
+	}
+	aead, err := newSMBMaterialAEAD(secret.value)
+	if err != nil {
+		return "", err
+	}
+	if len(nonce) != aead.NonceSize() {
+		return "", errors.New("invalid smb material nonce size")
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt smb material: %w", err)
+	}
+
+	password := string(plaintext)
 	if password == "" {
 		return "", errors.New("empty smb password material")
 	}
 	return password, nil
 }
 
-func decodeEncryptedSMBMaterial(material string) (string, bool, error) {
-	payload := strings.TrimSpace(material)
-	parts := strings.Split(payload, ":")
-	if len(parts) != 3 || parts[0] != "enc" {
-		return "", false, errors.New("invalid smb material format")
-	}
-
-	nonce, err := base64.StdEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", false, fmt.Errorf("invalid smb material nonce: %w", err)
-	}
-	ciphertext, err := base64.StdEncoding.DecodeString(parts[2])
-	if err != nil {
-		return "", false, fmt.Errorf("invalid smb material ciphertext: %w", err)
-	}
-
-	secrets, err := resolveSMBMaterialDecryptionSecrets()
-	if err != nil {
-		return "", false, err
-	}
-
-	var lastErr error
-	for _, secret := range secrets {
-		aead, err := newSMBMaterialAEAD(secret.value)
-		if err != nil {
-			return "", false, err
-		}
-		if len(nonce) != aead.NonceSize() {
-			return "", false, errors.New("invalid smb material nonce size")
-		}
-		plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		password := string(plaintext)
-		if password == "" {
-			return "", false, errors.New("empty smb password material")
-		}
-		return password, secret.legacy, nil
-	}
-
-	if lastErr == nil {
-		lastErr = errors.New("failed to decrypt smb material")
-	}
-	return "", false, fmt.Errorf("failed to decrypt smb material: %w", lastErr)
-}
-
-func resolvePrimarySMBMaterialSecret() (smbMaterialSecret, error) {
+func resolvePrimarySMBMaterialSecretWithoutBootstrap() (smbMaterialSecret, error) {
 	secret := strings.TrimSpace(os.Getenv("COHESION_SMB_MATERIAL_KEY"))
 	if secret != "" {
 		return smbMaterialSecret{
@@ -683,38 +701,120 @@ func resolvePrimarySMBMaterialSecret() (smbMaterialSecret, error) {
 			source: smbMaterialKeySourceEnv,
 		}, nil
 	}
-	if IsSMBMaterialKeyRequired() {
-		return smbMaterialSecret{}, errors.New("COHESION_SMB_MATERIAL_KEY is required when SMB is enabled in production")
+
+	path, err := resolveSMBMaterialKeyPath()
+	if err != nil {
+		return smbMaterialSecret{}, err
 	}
-	return smbMaterialSecret{
-		value:  defaultSMBMaterialKey,
-		source: smbMaterialKeySourceFallback,
-	}, nil
+
+	secret, exists, err := readSMBMaterialSecretFromFile(path)
+	if err != nil {
+		return smbMaterialSecret{}, err
+	}
+	if exists {
+		return smbMaterialSecret{
+			value:  secret,
+			source: smbMaterialKeySourceFileExisting,
+		}, nil
+	}
+
+	return smbMaterialSecret{}, missingSMBMaterialKeyError()
 }
 
-func resolveSMBMaterialDecryptionSecrets() ([]smbMaterialSecret, error) {
-	primary, err := resolvePrimarySMBMaterialSecret()
-	if err != nil {
-		return nil, err
+func (s *Service) resolvePrimarySMBMaterialSecret(ctx context.Context) (smbMaterialSecret, error) {
+	secret, err := resolvePrimarySMBMaterialSecretWithoutBootstrap()
+	if err == nil {
+		return secret, nil
 	}
-	secrets := []smbMaterialSecret{primary}
+	if !errors.Is(err, errSMBMaterialKeyMissing) {
+		return smbMaterialSecret{}, err
+	}
 
-	legacyJWT := strings.TrimSpace(os.Getenv("COHESION_JWT_SECRET"))
-	if legacyJWT != "" && legacyJWT != primary.value {
-		secrets = append(secrets, smbMaterialSecret{
-			value:  legacyJWT,
-			source: smbMaterialKeySourceLegacyJWT,
-			legacy: true,
-		})
+	hasCredentials, err := s.hasAnySMBCredential(ctx)
+	if err != nil {
+		return smbMaterialSecret{}, fmt.Errorf("check existing smb credentials: %w", err)
 	}
-	if defaultSMBMaterialKey != primary.value {
-		secrets = append(secrets, smbMaterialSecret{
-			value:  defaultSMBMaterialKey,
-			source: smbMaterialKeySourceLegacyDefault,
-			legacy: true,
-		})
+	if hasCredentials {
+		return smbMaterialSecret{}, missingSMBMaterialKeyWithCredentialDataError()
 	}
-	return secrets, nil
+
+	if IsSMBMaterialKeyRequired() {
+		return smbMaterialSecret{}, missingSMBMaterialKeyError()
+	}
+
+	return smbMaterialSecret{}, missingSMBMaterialKeyPrewarmRequiredError()
+}
+
+func (s *Service) hasAnySMBCredential(ctx context.Context) (bool, error) {
+	if s == nil || s.store == nil {
+		return false, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.store.HasAnySMBCredential(ctx)
+}
+
+func resolveSMBMaterialKeyPath() (string, error) {
+	if customPath := strings.TrimSpace(os.Getenv(smbMaterialKeyPathEnv)); customPath != "" {
+		return customPath, nil
+	}
+
+	userConfigDir, err := os.UserConfigDir()
+	if err == nil && strings.TrimSpace(userConfigDir) != "" {
+		return filepath.Join(userConfigDir, "Cohesion", "secrets", defaultSMBMaterialKeyFile), nil
+	}
+
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", errors.New("failed to resolve smb material key path")
+	}
+	return filepath.Join(filepath.Dir(executablePath), "data", defaultSMBMaterialKeyFile), nil
+}
+
+func readSMBMaterialSecretFromFile(path string) (string, bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	secret := strings.TrimSpace(string(content))
+	if secret == "" {
+		return "", false, nil
+	}
+	return secret, true, nil
+}
+
+func writeSMBMaterialSecretToFile(path, secret string) error {
+	if err := os.MkdirAll(filepath.Dir(path), smbMaterialKeyDirPermission); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(secret+"\n"), smbMaterialKeyFilePermission)
+}
+
+func generateRandomSMBMaterialSecret(size int) (string, error) {
+	if size < 32 {
+		return "", errors.New("secret size must be at least 32 bytes")
+	}
+	buffer := make([]byte, size)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func missingSMBMaterialKeyError() error {
+	return fmt.Errorf("%w: set COHESION_SMB_MATERIAL_KEY or COHESION_SMB_MATERIAL_KEY_FILE", errSMBMaterialKeyMissing)
+}
+
+func missingSMBMaterialKeyPrewarmRequiredError() error {
+	return fmt.Errorf("%w: run startup prewarm before handling SMB credentials", errSMBMaterialKeyMissing)
+}
+
+func missingSMBMaterialKeyWithCredentialDataError() error {
+	return fmt.Errorf("%w: SMB material key is missing while existing SMB credential data is present; restore COHESION_SMB_MATERIAL_KEY or COHESION_SMB_MATERIAL_KEY_FILE from backup", ErrSMBCredentialRecoveryRequired)
 }
 
 func newSMBMaterialAEAD(secret string) (cipher.AEAD, error) {

--- a/apps/backend/internal/account/service_smb_credentials_test.go
+++ b/apps/backend/internal/account/service_smb_credentials_test.go
@@ -2,13 +2,9 @@ package account_test
 
 import (
 	"context"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
-	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -67,105 +63,44 @@ func TestCreateAndUpdateUser_RefreshesSMBCredentialMaterial(t *testing.T) {
 	}
 }
 
-func TestResolveSMBPassword_MigratesLegacyMaterialVersion(t *testing.T) {
+func TestPrewarmSMBMaterialKey_BootstrapsSMBKeyFileWhenNoCredentialData(t *testing.T) {
 	account.SetSMBMaterialKeyRequired(false)
 	t.Cleanup(func() {
 		account.SetSMBMaterialKeyRequired(false)
 	})
-	t.Setenv("COHESION_SMB_MATERIAL_KEY", "migration-key")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+
+	secretPath := filepath.Join(t.TempDir(), "smb_material_key")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", secretPath)
 
 	svc, db := setupRBACService(t)
 	defer db.Close()
 
 	ctx := context.Background()
-	password := "legacy-password"
+	prewarm, err := svc.PrewarmSMBMaterialKey(ctx)
+	if err != nil {
+		t.Fatalf("prewarm smb key: %v", err)
+	}
+	if prewarm.Source != "generated" {
+		t.Fatalf("expected generated source on first prewarm, got %q", prewarm.Source)
+	}
+
 	user, err := svc.CreateUser(ctx, &account.CreateUserRequest{
-		Username: "legacy-user",
-		Password: password,
-		Nickname: "Legacy User",
+		Username: "bootstrap-user",
+		Password: "bootstrap-password",
+		Nickname: "Bootstrap User",
 		Role:     account.RoleUser,
 	})
 	if err != nil {
-		t.Fatalf("create user: %v", err)
+		t.Fatalf("create user with bootstrap key: %v", err)
 	}
 
-	legacyMaterial := "plain:" + base64.StdEncoding.EncodeToString([]byte(password))
-	if _, err := db.ExecContext(
-		ctx,
-		"UPDATE user_smb_credentials SET smb_material = ?, material_version = ? WHERE user_id = ?",
-		legacyMaterial,
-		3,
-		user.ID,
-	); err != nil {
-		t.Fatalf("seed legacy smb material: %v", err)
-	}
-
-	resolved, err := svc.ResolveSMBPassword(ctx, user.Username)
+	content, err := os.ReadFile(secretPath)
 	if err != nil {
-		t.Fatalf("resolve smb password: %v", err)
+		t.Fatalf("read generated smb key file: %v", err)
 	}
-	if resolved != password {
-		t.Fatalf("expected resolved password %q, got %q", password, resolved)
-	}
-
-	credential, err := svc.GetSMBCredential(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("get smb credential: %v", err)
-	}
-	if credential.MaterialVersion != 4 {
-		t.Fatalf("expected migrated material version 4, got %d", credential.MaterialVersion)
-	}
-	if !strings.HasPrefix(credential.SMBMaterial, "enc:") {
-		t.Fatalf("expected encrypted smb material after migration, got %q", credential.SMBMaterial)
-	}
-	if credential.SMBMaterial == legacyMaterial {
-		t.Fatal("expected migrated smb material to differ from legacy payload")
-	}
-}
-
-func TestResolveSMBPassword_MigratesLegacyJWTFallbackCiphertext(t *testing.T) {
-	account.SetSMBMaterialKeyRequired(true)
-	t.Cleanup(func() {
-		account.SetSMBMaterialKeyRequired(false)
-	})
-	t.Setenv("COHESION_SMB_MATERIAL_KEY", "current-material-key")
-	t.Setenv("COHESION_JWT_SECRET", "legacy-jwt-key")
-
-	svc, db := setupRBACService(t)
-	defer db.Close()
-
-	ctx := context.Background()
-	password := "jwt-legacy-password"
-	user, err := svc.CreateUser(ctx, &account.CreateUserRequest{
-		Username: "legacy-jwt-user",
-		Password: password,
-		Nickname: "Legacy JWT User",
-		Role:     account.RoleUser,
-	})
-	if err != nil {
-		t.Fatalf("create user: %v", err)
-	}
-
-	legacyEncrypted, err := encryptForSMBMaterial("legacy-jwt-key", password)
-	if err != nil {
-		t.Fatalf("encrypt legacy jwt payload: %v", err)
-	}
-	if _, err := db.ExecContext(
-		ctx,
-		"UPDATE user_smb_credentials SET smb_material = ?, material_version = ? WHERE user_id = ?",
-		legacyEncrypted,
-		4,
-		user.ID,
-	); err != nil {
-		t.Fatalf("seed legacy jwt encrypted smb material: %v", err)
-	}
-
-	resolved, err := svc.ResolveSMBPassword(ctx, user.Username)
-	if err != nil {
-		t.Fatalf("resolve smb password: %v", err)
-	}
-	if resolved != password {
-		t.Fatalf("expected resolved password %q, got %q", password, resolved)
+	if strings.TrimSpace(string(content)) == "" {
+		t.Fatalf("expected non-empty smb key file, got %q", string(content))
 	}
 
 	credential, err := svc.GetSMBCredential(ctx, user.ID)
@@ -175,8 +110,82 @@ func TestResolveSMBPassword_MigratesLegacyJWTFallbackCiphertext(t *testing.T) {
 	if credential.MaterialVersion != 4 {
 		t.Fatalf("expected material version 4, got %d", credential.MaterialVersion)
 	}
-	if credential.SMBMaterial == legacyEncrypted {
-		t.Fatal("expected legacy jwt ciphertext to be re-encrypted with current smb key")
+	if !strings.HasPrefix(credential.SMBMaterial, "enc:") {
+		t.Fatalf("expected encrypted smb material, got %q", credential.SMBMaterial)
+	}
+}
+
+func TestPrewarmSMBMaterialKey_ReusesExistingKeyFile(t *testing.T) {
+	account.SetSMBMaterialKeyRequired(false)
+	t.Cleanup(func() {
+		account.SetSMBMaterialKeyRequired(false)
+	})
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+
+	secretPath := filepath.Join(t.TempDir(), "smb_material_key")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", secretPath)
+
+	svc, db := setupRBACService(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	first, err := svc.PrewarmSMBMaterialKey(ctx)
+	if err != nil {
+		t.Fatalf("first prewarm smb key: %v", err)
+	}
+	if first.Source != "generated" {
+		t.Fatalf("expected generated source, got %q", first.Source)
+	}
+
+	firstContent, err := os.ReadFile(secretPath)
+	if err != nil {
+		t.Fatalf("read first key file: %v", err)
+	}
+
+	second, err := svc.PrewarmSMBMaterialKey(ctx)
+	if err != nil {
+		t.Fatalf("second prewarm smb key: %v", err)
+	}
+	if second.Source != "file" {
+		t.Fatalf("expected file source on second prewarm, got %q", second.Source)
+	}
+
+	secondContent, err := os.ReadFile(secretPath)
+	if err != nil {
+		t.Fatalf("read second key file: %v", err)
+	}
+	if strings.TrimSpace(string(firstContent)) != strings.TrimSpace(string(secondContent)) {
+		t.Fatal("expected smb key file to be reused without regeneration")
+	}
+}
+
+func TestPrepareSMBCredential_ReturnsRecoverableErrorWhenKeyMissingWithExistingCredentialData(t *testing.T) {
+	account.SetSMBMaterialKeyRequired(false)
+	t.Cleanup(func() {
+		account.SetSMBMaterialKeyRequired(false)
+	})
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "bootstrap-key")
+
+	svc, db := setupRBACService(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	password := "strict-policy-password"
+	if _, err := svc.CreateUser(ctx, &account.CreateUserRequest{
+		Username: "strict-user",
+		Password: password,
+		Nickname: "Strict User",
+		Role:     account.RoleUser,
+	}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", filepath.Join(t.TempDir(), "missing_smb_material_key"))
+
+	err := svc.PrepareSMBCredential(ctx, "strict-user", password)
+	if !errors.Is(err, account.ErrSMBCredentialRecoveryRequired) {
+		t.Fatalf("expected recoverable smb credential error, got %v", err)
 	}
 }
 
@@ -217,51 +226,40 @@ func TestResolveSMBPassword_ReturnsRecoverableErrorOnDecodeFailure(t *testing.T)
 	}
 }
 
-func TestPrepareSMBCredential_ReturnsRecoverableErrorWhenKeyMissingUnderStrictPolicy(t *testing.T) {
+func TestResolveSMBPassword_ReturnsRecoverableErrorOnLegacyMaterialVersion(t *testing.T) {
 	account.SetSMBMaterialKeyRequired(false)
 	t.Cleanup(func() {
 		account.SetSMBMaterialKeyRequired(false)
 	})
-	t.Setenv("COHESION_SMB_MATERIAL_KEY", "bootstrap-key")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "legacy-unsupported-key")
 
 	svc, db := setupRBACService(t)
 	defer db.Close()
 
 	ctx := context.Background()
-	password := "strict-policy-password"
-	if _, err := svc.CreateUser(ctx, &account.CreateUserRequest{
-		Username: "strict-user",
+	password := "legacy-password"
+	user, err := svc.CreateUser(ctx, &account.CreateUserRequest{
+		Username: "legacy-user",
 		Password: password,
-		Nickname: "Strict User",
+		Nickname: "Legacy User",
 		Role:     account.RoleUser,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
-	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
-	account.SetSMBMaterialKeyRequired(true)
+	if _, err := db.ExecContext(
+		ctx,
+		"UPDATE user_smb_credentials SET smb_material = ?, material_version = ? WHERE user_id = ?",
+		"plain:Zm9v",
+		3,
+		user.ID,
+	); err != nil {
+		t.Fatalf("seed legacy smb material: %v", err)
+	}
 
-	err := svc.PrepareSMBCredential(ctx, "strict-user", password)
+	_, err = svc.ResolveSMBPassword(ctx, user.Username)
 	if !errors.Is(err, account.ErrSMBCredentialRecoveryRequired) {
 		t.Fatalf("expected recoverable smb credential error, got %v", err)
 	}
-}
-
-func encryptForSMBMaterial(secret, password string) (string, error) {
-	key := sha256.Sum256([]byte(secret))
-	block, err := aes.NewCipher(key[:])
-	if err != nil {
-		return "", err
-	}
-	aead, err := cipher.NewGCM(block)
-	if err != nil {
-		return "", err
-	}
-
-	nonce := make([]byte, aead.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", err
-	}
-	ciphertext := aead.Seal(nil, nonce, []byte(password), nil)
-	return "enc:" + base64.StdEncoding.EncodeToString(nonce) + ":" + base64.StdEncoding.EncodeToString(ciphertext), nil
 }

--- a/apps/backend/internal/account/store/store.go
+++ b/apps/backend/internal/account/store/store.go
@@ -505,3 +505,23 @@ func (s *Store) GetSMBCredential(ctx context.Context, userID int64) (*account.SM
 
 	return &credential, nil
 }
+
+func (s *Store) HasAnySMBCredential(ctx context.Context) (bool, error) {
+	query, args, err := s.qb.
+		Select("1").
+		From("user_smb_credentials").
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return false, err
+	}
+
+	var marker int
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&marker); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/apps/backend/internal/sftp/service.go
+++ b/apps/backend/internal/sftp/service.go
@@ -45,6 +45,11 @@ type Service struct {
 	mu             sync.RWMutex
 }
 
+type HostKeyPrewarmResult struct {
+	Source string
+	Path   string
+}
+
 func NewService(spaceService *space.Service, accountService *account.Service, enabled bool, port int) *Service {
 	if port <= 0 {
 		port = defaultSFTPPort
@@ -70,7 +75,7 @@ func (s *Service) Start() error {
 		return nil
 	}
 
-	hostSigner, hostKeyPath, err := loadOrCreateHostSigner()
+	hostSigner, hostKeyPath, hostKeyCreated, err := loadOrCreateHostSigner()
 	if err != nil {
 		return err
 	}
@@ -105,6 +110,7 @@ func (s *Service) Start() error {
 		log.Info().
 			Int("port", s.port).
 			Str("host_key_path", hostKeyPath).
+			Bool("host_key_generated", hostKeyCreated).
 			Msg("[SFTP] server started")
 		return nil
 	}
@@ -171,37 +177,56 @@ func (s *Service) handleSFTPSubsystem(session gliderssh.Session) {
 	}
 }
 
-func loadOrCreateHostSigner() (xssh.Signer, string, error) {
+func PrewarmHostKey() (HostKeyPrewarmResult, error) {
+	hasEnvPathOverride := strings.TrimSpace(os.Getenv(sftpHostKeyFilePathEnv)) != ""
+
+	_, keyPath, created, err := loadOrCreateHostSigner()
+	if err != nil {
+		return HostKeyPrewarmResult{}, err
+	}
+	source := "file"
+	if created {
+		source = "generated"
+	} else if hasEnvPathOverride {
+		source = "env"
+	}
+	return HostKeyPrewarmResult{
+		Source: source,
+		Path:   keyPath,
+	}, nil
+}
+
+func loadOrCreateHostSigner() (xssh.Signer, string, bool, error) {
 	keyPath, err := resolveHostKeyPath()
 	if err != nil {
-		return nil, "", err
+		return nil, "", false, err
 	}
 
 	keyBytes, err := os.ReadFile(keyPath)
 	if err == nil {
 		signer, parseErr := xssh.ParsePrivateKey(keyBytes)
 		if parseErr != nil {
-			return nil, "", fmt.Errorf("parse sftp host key: %w", parseErr)
+			return nil, "", false, fmt.Errorf("parse sftp host key: %w", parseErr)
 		}
-		return signer, keyPath, nil
+		return signer, keyPath, false, nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) {
-		return nil, "", fmt.Errorf("read sftp host key: %w", err)
+		return nil, "", false, fmt.Errorf("read sftp host key: %w", err)
 	}
 
 	signer, pemBytes, err := generateHostSigner()
 	if err != nil {
-		return nil, "", err
+		return nil, "", false, err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(keyPath), sftpKeyDirPermission); err != nil {
-		return nil, "", fmt.Errorf("create sftp host key directory: %w", err)
+		return nil, "", false, fmt.Errorf("create sftp host key directory: %w", err)
 	}
 	if err := os.WriteFile(keyPath, pemBytes, sftpKeyFilePermission); err != nil {
-		return nil, "", fmt.Errorf("write sftp host key: %w", err)
+		return nil, "", false, fmt.Errorf("write sftp host key: %w", err)
 	}
 
-	return signer, keyPath, nil
+	return signer, keyPath, true, nil
 }
 
 func resolveHostKeyPath() (string, error) {

--- a/apps/backend/internal/sftp/service_test.go
+++ b/apps/backend/internal/sftp/service_test.go
@@ -1,0 +1,43 @@
+package sftp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrewarmHostKey_SourceGeneratedThenEnvWithEnvPathOverride(t *testing.T) {
+	hostKeyPath := filepath.Join(t.TempDir(), "sftp_host_key")
+	t.Setenv("COHESION_SFTP_HOST_KEY_FILE", hostKeyPath)
+
+	first, err := PrewarmHostKey()
+	if err != nil {
+		t.Fatalf("first prewarm host key: %v", err)
+	}
+	if first.Source != "generated" {
+		t.Fatalf("expected generated source on first prewarm, got %q", first.Source)
+	}
+	if first.Path != hostKeyPath {
+		t.Fatalf("expected host key path %q, got %q", hostKeyPath, first.Path)
+	}
+
+	second, err := PrewarmHostKey()
+	if err != nil {
+		t.Fatalf("second prewarm host key: %v", err)
+	}
+	if second.Source != "env" {
+		t.Fatalf("expected env source on second prewarm with env path override, got %q", second.Source)
+	}
+	if second.Path != hostKeyPath {
+		t.Fatalf("expected host key path %q, got %q", hostKeyPath, second.Path)
+	}
+
+	content, err := os.ReadFile(hostKeyPath)
+	if err != nil {
+		t.Fatalf("read generated host key: %v", err)
+	}
+	if strings.TrimSpace(string(content)) == "" {
+		t.Fatalf("expected non-empty host key file, got %q", string(content))
+	}
+}

--- a/apps/backend/main.go
+++ b/apps/backend/main.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
@@ -55,6 +56,16 @@ var (
 			Str(logging.FieldComponent, logging.ComponentAccess).
 			Logger()
 )
+
+type prewarmedSecrets struct {
+	jwtSecret string
+}
+
+type jwtSecretResult struct {
+	value  string
+	source string
+	path   string
+}
 
 // 재시작 신호를 받기 위한 채널
 var restartChan = make(chan bool, 1)
@@ -171,23 +182,24 @@ func registerWebDAVRoutes(mux *http.ServeMux, handler http.Handler) {
 
 // createServer는 설정을 기반으로 HTTP 서버를 생성합니다
 func createServer(db *sql.DB, restartChan chan bool, shutdownChan chan struct{}) (*http.Server, *ftp.Service, *sftpserver.Service, *smb.Service, *audit.Service, error) {
-	if err := configureSMBMaterialKeyPolicy(config.Conf.Server.SmbEnabled); err != nil {
-		return nil, nil, nil, nil, nil, err
-	}
-
 	// 의존성 주입
 	accountRepo := accountStore.NewStore(db)
 	accountService := account.NewService(accountRepo)
-	if err := accountService.EnsureDefaultAdmin(context.Background()); err != nil {
+
+	prewarmed, err := prewarmRequiredSecrets(context.Background(), accountService)
+	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	authSecret, err := resolveJWTSecret()
-	if err != nil {
+
+	if err := configureSMBMaterialKeyPolicy(accountService, config.Conf.Server.SmbEnabled); err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	if err := accountService.EnsureDefaultAdmin(context.Background()); err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 	accountHandler := account.NewHandler(accountService)
 	authService := auth.NewService(accountService, auth.Config{
-		Secret:         authSecret,
+		Secret:         prewarmed.jwtSecret,
 		Issuer:         "cohesion",
 		AccessTokenTTL: 15 * time.Minute,
 		RefreshTTL:     7 * 24 * time.Hour,
@@ -587,11 +599,73 @@ func readEnv(key, fallback string) string {
 	return value
 }
 
-func configureSMBMaterialKeyPolicy(smbEnabled bool) error {
+func prewarmRequiredSecrets(ctx context.Context, accountService *account.Service) (prewarmedSecrets, error) {
+	if accountService == nil {
+		return prewarmedSecrets{}, wrapSecretBootstrapError("account_service", errors.New("account service is required"))
+	}
+
+	jwtResult, err := prewarmJWTSecret()
+	if err != nil {
+		return prewarmedSecrets{}, wrapSecretBootstrapError("jwt", err)
+	}
+	logSecretPrewarm("jwt", jwtResult.source, jwtResult.path)
+
+	smbResult, err := accountService.PrewarmSMBMaterialKey(ctx)
+	if err != nil {
+		return prewarmedSecrets{}, wrapSecretBootstrapError("smb_material_key", err)
+	}
+	logSecretPrewarm("smb_material_key", smbResult.Source, smbResult.Path)
+
+	sftpResult, err := sftpserver.PrewarmHostKey()
+	if err != nil {
+		return prewarmedSecrets{}, wrapSecretBootstrapError("sftp_host_key", err)
+	}
+	logSecretPrewarm("sftp_host_key", sftpResult.Source, sftpResult.Path)
+
+	return prewarmedSecrets{jwtSecret: jwtResult.value}, nil
+}
+
+func logSecretPrewarm(secretName, source, path string) {
+	event := logging.Event(log.Info(), logging.ComponentMain, logging.EventServiceReady).
+		Str("service", "secret-prewarm").
+		Str("secret_name", secretName).
+		Str("source", source)
+
+	if trimmedPath := strings.TrimSpace(path); trimmedPath != "" {
+		event = event.Str("path", trimmedPath)
+	}
+
+	event.Msg("service status updated")
+}
+
+func wrapSecretBootstrapError(secretName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("required secret bootstrap failed [%s]: %w", secretName, err)
+}
+
+func configureSMBMaterialKeyPolicy(accountService *account.Service, smbEnabled bool) error {
 	requireSMBMaterialKey := goEnv == "production" && smbEnabled
 	account.SetSMBMaterialKeyRequired(requireSMBMaterialKey)
 
-	if err := account.ValidateSMBMaterialKeyConfiguration(); err != nil {
+	if !smbEnabled {
+		logging.Event(log.Info(), logging.ComponentAuth, logging.EventServiceReady).
+			Str("service", "smb-material-key-boundary").
+			Str("environment", goEnv).
+			Bool("smb_enabled", smbEnabled).
+			Bool("key_required", requireSMBMaterialKey).
+			Str("key_source", "n/a").
+			Msg("service status updated")
+		return nil
+	}
+
+	if accountService == nil {
+		return errors.New("account service is required for SMB material key policy")
+	}
+
+	keySource, err := accountService.ValidateSMBMaterialKeyConfiguration(context.Background())
+	if err != nil {
 		logging.Event(log.Error(), logging.ComponentAuth, "error.smb.material_key_invalid").
 			Err(err).
 			Str("environment", goEnv).
@@ -606,48 +680,54 @@ func configureSMBMaterialKeyPolicy(smbEnabled bool) error {
 		Str("environment", goEnv).
 		Bool("smb_enabled", smbEnabled).
 		Bool("key_required", requireSMBMaterialKey).
-		Str("key_source", account.CurrentSMBMaterialKeySource()).
+		Str("key_source", keySource).
 		Msg("service status updated")
 	return nil
 }
 
 func resolveJWTSecret() (string, error) {
+	result, err := prewarmJWTSecret()
+	if err != nil {
+		return "", err
+	}
+	return result.value, nil
+}
+
+func prewarmJWTSecret() (jwtSecretResult, error) {
 	secret := strings.TrimSpace(os.Getenv("COHESION_JWT_SECRET"))
 	if secret != "" {
 		if goEnv == "production" && len(secret) < 32 {
-			return "", errors.New("COHESION_JWT_SECRET must be at least 32 characters in production")
+			return jwtSecretResult{}, errors.New("COHESION_JWT_SECRET must be at least 32 characters in production")
 		}
-		logging.Event(log.Info(), logging.ComponentAuth, logging.EventServiceReady).
-			Str("service", "jwt-secret").
-			Str("source", "env:COHESION_JWT_SECRET").
-			Msg("service status updated")
-		return secret, nil
+		return jwtSecretResult{
+			value:  secret,
+			source: "env",
+		}, nil
 	}
 
 	secretFilePath, err := resolveJWTSecretPath()
 	if err != nil {
-		return "", err
+		return jwtSecretResult{}, err
 	}
 
-	secret, created, err := loadOrCreateJWTSecret(secretFilePath, goEnv != "production")
+	secret, created, err := loadOrCreateJWTSecret(secretFilePath, true)
 	if err != nil {
-		return "", err
+		return jwtSecretResult{}, err
 	}
 
 	if goEnv == "production" && len(secret) < 32 {
-		return "", errors.New("COHESION_JWT_SECRET must be at least 32 characters in production")
+		return jwtSecretResult{}, errors.New("COHESION_JWT_SECRET must be at least 32 characters in production")
 	}
 
-	source := "file:existing"
+	source := "file"
 	if created {
-		source = "file:generated"
+		source = "generated"
 	}
-	logging.Event(log.Info(), logging.ComponentAuth, logging.EventServiceReady).
-		Str("service", "jwt-secret").
-		Str("source", source).
-		Str("path", secretFilePath).
-		Msg("service status updated")
-	return secret, nil
+	return jwtSecretResult{
+		value:  secret,
+		source: source,
+		path:   secretFilePath,
+	}, nil
 }
 
 func resolveJWTSecretPath() (string, error) {

--- a/apps/backend/main_test.go
+++ b/apps/backend/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,7 +13,11 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/ncruces/go-sqlite3/driver"
+	_ "github.com/ncruces/go-sqlite3/embed"
 	"taeu.kr/cohesion/internal/account"
+	accountStore "taeu.kr/cohesion/internal/account/store"
+	"taeu.kr/cohesion/internal/platform/database"
 	"taeu.kr/cohesion/internal/platform/logging"
 )
 
@@ -80,19 +87,154 @@ func TestEmitAccessLog_OmitsQueryWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestResolveJWTSecret_ProductionRejectsMissingSecret(t *testing.T) {
+func TestResolveJWTSecret_ProductionGeneratesSecretFileWhenMissing(t *testing.T) {
 	setGoEnvForTest(t, "production")
 	t.Setenv("COHESION_JWT_SECRET", "")
 
 	secretFile := filepath.Join(t.TempDir(), "jwt_secret")
 	t.Setenv("COHESION_JWT_SECRET_FILE", secretFile)
 
-	_, err := resolveJWTSecret()
-	if err == nil {
-		t.Fatal("expected error when production jwt secret is missing")
+	secret, err := resolveJWTSecret()
+	if err != nil {
+		t.Fatalf("resolve jwt secret: %v", err)
 	}
-	if !strings.Contains(err.Error(), "COHESION_JWT_SECRET is required in production") {
-		t.Fatalf("unexpected error: %v", err)
+	if strings.TrimSpace(secret) == "" {
+		t.Fatal("expected non-empty jwt secret")
+	}
+	content, err := os.ReadFile(secretFile)
+	if err != nil {
+		t.Fatalf("read generated jwt secret file: %v", err)
+	}
+	if strings.TrimSpace(string(content)) == "" {
+		t.Fatalf("expected generated jwt secret file to be non-empty, got %q", string(content))
+	}
+}
+
+func TestPrewarmRequiredSecrets_FirstRunGeneratesAndRestartReuses(t *testing.T) {
+	setGoEnvForTest(t, "development")
+
+	secretDir := t.TempDir()
+	jwtPath := filepath.Join(secretDir, "jwt_secret")
+	smbPath := filepath.Join(secretDir, "smb_material_key")
+	sftpPath := filepath.Join(secretDir, "sftp_host_key")
+
+	t.Setenv("COHESION_JWT_SECRET", "")
+	t.Setenv("COHESION_JWT_SECRET_FILE", jwtPath)
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", smbPath)
+	t.Setenv("COHESION_SFTP_HOST_KEY_FILE", sftpPath)
+
+	svc, db := setupSMBMaterialPolicyService(t)
+	defer db.Close()
+
+	first, err := prewarmRequiredSecrets(context.Background(), svc)
+	if err != nil {
+		t.Fatalf("first prewarm: %v", err)
+	}
+	if strings.TrimSpace(first.jwtSecret) == "" {
+		t.Fatal("expected prewarmed jwt secret")
+	}
+
+	jwtBefore := readTrimmedFile(t, jwtPath)
+	smbBefore := readTrimmedFile(t, smbPath)
+	sftpBefore := readTrimmedFile(t, sftpPath)
+	if jwtBefore == "" || smbBefore == "" || sftpBefore == "" {
+		t.Fatal("expected first prewarm to generate all required secret files")
+	}
+
+	second, err := prewarmRequiredSecrets(context.Background(), svc)
+	if err != nil {
+		t.Fatalf("second prewarm: %v", err)
+	}
+	if first.jwtSecret != second.jwtSecret {
+		t.Fatalf("expected jwt secret reuse, first=%q second=%q", first.jwtSecret, second.jwtSecret)
+	}
+
+	if jwtBefore != readTrimmedFile(t, jwtPath) {
+		t.Fatal("expected jwt secret file to be reused on restart")
+	}
+	if smbBefore != readTrimmedFile(t, smbPath) {
+		t.Fatal("expected smb key file to be reused on restart")
+	}
+	if sftpBefore != readTrimmedFile(t, sftpPath) {
+		t.Fatal("expected sftp host key file to be reused on restart")
+	}
+}
+
+func TestPrewarmRequiredSecrets_FailsWhenSMBKeyMissingWithExistingCredentialData(t *testing.T) {
+	setGoEnvForTest(t, "development")
+
+	secretDir := t.TempDir()
+	jwtPath := filepath.Join(secretDir, "jwt_secret")
+	smbPath := filepath.Join(secretDir, "smb_material_key")
+	sftpPath := filepath.Join(secretDir, "sftp_host_key")
+
+	t.Setenv("COHESION_JWT_SECRET", "")
+	t.Setenv("COHESION_JWT_SECRET_FILE", jwtPath)
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "seed-smb-key")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", smbPath)
+	t.Setenv("COHESION_SFTP_HOST_KEY_FILE", sftpPath)
+
+	svc, db := setupSMBMaterialPolicyService(t)
+	defer db.Close()
+
+	_, err := svc.CreateUser(context.Background(), &account.CreateUserRequest{
+		Username: "prewarm-fail-user",
+		Password: "prewarm-fail-password",
+		Nickname: "Prewarm Fail User",
+		Role:     account.RoleUser,
+	})
+	if err != nil {
+		t.Fatalf("create user for smb credential seed: %v", err)
+	}
+
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", filepath.Join(secretDir, "missing_smb_material_key"))
+
+	_, err = prewarmRequiredSecrets(context.Background(), svc)
+	if err == nil {
+		t.Fatal("expected startup prewarm failure when smb key is missing with existing credential data")
+	}
+	if !errors.Is(err, account.ErrSMBCredentialRecoveryRequired) {
+		t.Fatalf("expected recoverable smb key guidance error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "restore COHESION_SMB_MATERIAL_KEY or COHESION_SMB_MATERIAL_KEY_FILE") {
+		t.Fatalf("expected restore guidance in error, got %v", err)
+	}
+}
+
+func TestPrewarmRequiredSecrets_FailsWithUnderlyingSMBKeyReadError(t *testing.T) {
+	setGoEnvForTest(t, "development")
+
+	secretDir := t.TempDir()
+	jwtPath := filepath.Join(secretDir, "jwt_secret")
+	sftpPath := filepath.Join(secretDir, "sftp_host_key")
+	smbPathAsDirectory := filepath.Join(secretDir, "smb_key_dir")
+	if err := os.MkdirAll(smbPathAsDirectory, 0o755); err != nil {
+		t.Fatalf("create smb key directory fixture: %v", err)
+	}
+
+	t.Setenv("COHESION_JWT_SECRET", "")
+	t.Setenv("COHESION_JWT_SECRET_FILE", jwtPath)
+	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", smbPathAsDirectory)
+	t.Setenv("COHESION_SFTP_HOST_KEY_FILE", sftpPath)
+
+	svc, db := setupSMBMaterialPolicyService(t)
+	defer db.Close()
+
+	_, err := prewarmRequiredSecrets(context.Background(), svc)
+	if err == nil {
+		t.Fatal("expected startup prewarm failure when smb key path is unreadable")
+	}
+	if errors.Is(err, account.ErrSMBCredentialRecoveryRequired) {
+		t.Fatalf("expected raw bootstrap read error, got recoverable guidance: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[smb_material_key]") {
+		t.Fatalf("expected smb bootstrap context in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), smbPathAsDirectory) {
+		t.Fatalf("expected filesystem read error details in error, got %v", err)
 	}
 }
 
@@ -126,12 +268,16 @@ func TestConfigureSMBMaterialKeyPolicy_ProductionRequiresKeyWhenSMBEnabled(t *te
 		account.SetSMBMaterialKeyRequired(false)
 	})
 	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
+	t.Setenv("COHESION_SMB_MATERIAL_KEY_FILE", filepath.Join(t.TempDir(), "missing_smb_material_key"))
 
-	err := configureSMBMaterialKeyPolicy(true)
+	svc, db := setupSMBMaterialPolicyService(t)
+	defer db.Close()
+
+	err := configureSMBMaterialKeyPolicy(svc, true)
 	if err == nil {
 		t.Fatal("expected error when smb key is missing under production+smb_enabled")
 	}
-	if !strings.Contains(err.Error(), "COHESION_SMB_MATERIAL_KEY is required") {
+	if !strings.Contains(err.Error(), "smb material key missing") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -144,12 +290,35 @@ func TestConfigureSMBMaterialKeyPolicy_ProductionAllowsMissingKeyWhenSMBDisabled
 	})
 	t.Setenv("COHESION_SMB_MATERIAL_KEY", "")
 
-	if err := configureSMBMaterialKeyPolicy(false); err != nil {
+	if err := configureSMBMaterialKeyPolicy(nil, false); err != nil {
 		t.Fatalf("expected no error when smb key missing but smb disabled: %v", err)
 	}
 	if account.IsSMBMaterialKeyRequired() {
 		t.Fatal("expected smb material key requirement to remain disabled")
 	}
+}
+
+func setupSMBMaterialPolicyService(t *testing.T) (*account.Service, *sql.DB) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := database.Migrate(context.Background(), db); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+	return account.NewService(accountStore.NewStore(db)), db
+}
+
+func readTrimmedFile(t *testing.T, path string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(content))
 }
 
 func setGoEnvForTest(t *testing.T, env string) {

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -106,11 +106,14 @@ apps/backend/
 
 - JWT 서명 키와 SMB material 암호화 키를 분리 운영함.
   - JWT: `COHESION_JWT_SECRET` 또는 `COHESION_JWT_SECRET_FILE`
-  - SMB material: `COHESION_SMB_MATERIAL_KEY`
-- 프로덕션에서는 JWT 비밀이 누락되면 자동 생성하지 않고 기동 실패로 처리함.
-- 프로덕션에서 SMB가 활성화(`smb_enabled=true`)된 경우 `COHESION_SMB_MATERIAL_KEY` 누락 시 기동 실패로 처리함.
-- 개발/테스트에서는 SMB material 키 미설정 시 개발용 fallback 키를 허용함.
-- legacy SMB material 호환을 위해 복호화 시 JWT 기반 legacy key를 제한적으로 시도하고, 성공 시 현재 SMB key 기준으로 재암호화함.
+  - SMB material: `COHESION_SMB_MATERIAL_KEY` 또는 `COHESION_SMB_MATERIAL_KEY_FILE`
+- SFTP host key는 `COHESION_SFTP_HOST_KEY_FILE`(기본: configDir 기반 secrets 경로)로 관리한다.
+- 서버 startup prewarm 단계에서 JWT/SMB/SFTP 키를 일괄 준비한다(프로토콜 enable/disable와 무관).
+- source 우선순위는 공통으로 `env > persisted file > generated once`를 사용한다.
+- prewarm 결과는 운영 로그 `service=secret-prewarm`, `secret_name`, `source(env|file|generated)` 필드로 기록한다.
+- prewarm 실패 시 서버 기동을 중단한다(bootstrap 오류).
+- SMB credential 데이터가 존재하는 상태에서 key가 유실되면 자동 재생성하지 않고 복구 가이드 오류로 실패한다.
+- SMB material 복호화는 active SMB key 단일 소스만 사용한다(legacy JWT/dev fallback 및 자동 재암호화 제거).
 
 ---
 

--- a/docs/smb-rollout-playbook.md
+++ b/docs/smb-rollout-playbook.md
@@ -65,10 +65,11 @@ SMB를 기존 WEB/WebDAV/FTP/SFTP 운영 패턴과 일관되게 단계 도입하
 
 - JWT 토큰 서명 키와 SMB material 암호화 키는 분리 운영한다.
   - JWT: `COHESION_JWT_SECRET` (또는 `COHESION_JWT_SECRET_FILE`)
-  - SMB material: `COHESION_SMB_MATERIAL_KEY`
-- production + `smb_enabled=true`에서는 `COHESION_SMB_MATERIAL_KEY` 누락 시 서버 기동을 실패시킨다.
-- 개발/테스트에서는 `COHESION_SMB_MATERIAL_KEY` 미설정 시 개발용 기본 키 fallback을 허용한다.
-- legacy 데이터 전환을 위해 복호화 시 `COHESION_JWT_SECRET` 기반 legacy material 읽기를 제한적으로 허용하며, 성공 시 현재 SMB key 기준으로 재암호화한다.
+  - SMB material: `COHESION_SMB_MATERIAL_KEY` (또는 `COHESION_SMB_MATERIAL_KEY_FILE`)
+- startup prewarm에서 JWT/SMB/SFTP 키를 선확보한다(서비스 활성화 여부와 무관).
+- key source 우선순위는 `env > persisted file > generated once`로 통일한다.
+- 기존 SMB credential 데이터가 있는 상태에서 key가 없으면 자동 생성하지 않고 복구 필요 오류로 처리한다.
+- SMB material 복호화는 active SMB key 단일 소스만 사용한다(legacy fallback/decrypt migration 미지원).
 
 ## 기본 정책
 


### PR DESCRIPTION
## 요약
- startup secret prewarm 경로에서 SMB key read 오류가 generic missing-key 안내로 덮일 수 있는 문제를 수정했습니다.
- SFTP host key prewarm에서 env-path override(`COHESION_SFTP_HOST_KEY_FILE`) 재사용 시 source를 `env`로 분류하도록 정합화했습니다.
- startup prewarm 정책(JWT/SMB/SFTP) 테스트/문서를 함께 보강했습니다.

## 관련 이슈
- Closes #183

## 변경 사항
- `apps/backend/main.go`
  - `createServer` 선행 단계에 `prewarmRequiredSecrets` 추가
  - prewarm 실패 시 bootstrap 오류로 기동 중단
  - prewarm 표준 로그(`secret_name`, `source`, `path`) 기록
- `apps/backend/internal/account/service.go`
  - `PrewarmSMBMaterialKey` 추가
  - SMB key 해석 시 missing-error와 실제 read-error를 분리해 원인 보존
  - 기존 credential 데이터 + key missing 시 recoverable guidance 유지
- `apps/backend/internal/sftp/service.go`
  - `PrewarmHostKey` 노출
  - env-path override 재사용 시 source=`env` 분류
- 테스트
  - `apps/backend/main_test.go`
  - `apps/backend/internal/account/service_smb_credentials_test.go`
  - `apps/backend/internal/sftp/service_test.go` (신규)
- 문서
  - `docs/backend.md`
  - `docs/smb-rollout-playbook.md`

## 범위
- In Scope
  - startup secret prewarm 오류 전파 정합화
  - prewarm source 분류(`env|file|generated`) 정합화
  - 관련 테스트/문서 업데이트
- Out of Scope
  - key rotate 정책
  - 외부 KMS 연동
  - 분산 환경 secret 동기화

## 테스트/검증
- 자동 검증
  - `cd apps/backend && go test ./...` ✅
- 수동 검증 포인트
  - SMB key 경로 read 오류 시 원인 메시지 보존 확인
  - `COHESION_SFTP_HOST_KEY_FILE` 지정 후 재기동 시 source=`env` 확인

## 리스크 및 대응
- 리스크
  - prewarm 오류 메시지 변경으로 운영 알림 룰이 기존 문자열에 의존하면 영향 가능
- 대응
  - 오류 분류는 유지하고 원인 context만 강화
  - 문서에 prewarm/source 정책 명시
- 롤백
  - PR revert 시 기존 prewarm 전파/분류 동작으로 즉시 복귀 가능

## 리뷰 가이드
- 우선 확인 파일
  - `apps/backend/main.go`
  - `apps/backend/internal/account/service.go`
  - `apps/backend/internal/sftp/service.go`
  - `apps/backend/main_test.go`
  - `apps/backend/internal/sftp/service_test.go`
- 확인 포인트
  - read-error가 missing guidance로 치환되지 않는지
  - source 분류가 `env|file|generated`로 일관적인지

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #183`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음