### PR TITLE
fix: SMB key 조회 경로에 지연 bootstrap 보강

### DIFF
--- a/apps/backend/internal/account/service.go
+++ b/apps/backend/internal/account/service.go
@@ -742,7 +742,21 @@ func (s *Service) resolvePrimarySMBMaterialSecret(ctx context.Context) (smbMater
 		return smbMaterialSecret{}, missingSMBMaterialKeyError()
 	}
 
-	return smbMaterialSecret{}, missingSMBMaterialKeyPrewarmRequiredError()
+	if _, err := s.PrewarmSMBMaterialKey(ctx); err != nil {
+		if errors.Is(err, ErrSMBCredentialRecoveryRequired) {
+			return smbMaterialSecret{}, err
+		}
+		return smbMaterialSecret{}, fmt.Errorf("bootstrap smb material key: %w", err)
+	}
+
+	secret, err = resolvePrimarySMBMaterialSecretWithoutBootstrap()
+	if err == nil {
+		return secret, nil
+	}
+	if errors.Is(err, errSMBMaterialKeyMissing) {
+		return smbMaterialSecret{}, missingSMBMaterialKeyPrewarmRequiredError()
+	}
+	return smbMaterialSecret{}, err
 }
 
 func (s *Service) hasAnySMBCredential(ctx context.Context) (bool, error) {


### PR DESCRIPTION
### 요약
- 문제
  - Release workflow(Ubuntu)에서 `Run backend tests`가 실패했다.
  - 원인은 startup prewarm을 거치지 않은 경로에서 SMB material key가 없을 때 계정/인증/SMB 테스트가 연쇄 실패하는 점이었다.
- 해결
  - `resolvePrimarySMBMaterialSecret`에서 key 미존재 + 기존 SMB credential 데이터 없음 + non-required 모드일 때 내부적으로 `PrewarmSMBMaterialKey`를 호출해 1회 bootstrap 후 재조회하도록 수정했다.
  - 기존 SMB credential 데이터가 있는 경우에는 기존과 동일하게 복구 필요 오류(`ErrSMBCredentialRecoveryRequired`)를 유지한다.
- 기대 효과
  - Linux CI에서 startup prewarm 의존으로 인한 false failure 제거
  - 첫 실행 key 준비 정책은 유지하면서, prewarm 미호출 경로의 안정성 보강

### 관련 이슈
- Closes #185

### 변경 사항
- `apps/backend/internal/account/service.go`
  - `resolvePrimarySMBMaterialSecret` fallback 경로 보강
  - `IsSMBMaterialKeyRequired()==false` 조건에서 lazy bootstrap 시도 후 재조회
  - 복구 필요 오류 전파 유지

### 범위
- In Scope
  - SMB material key 조회 fallback 안정화
  - Linux 재현 환경 테스트 검증
- Out of Scope
  - 키 포맷/버전 변경
  - startup prewarm 정책 변경
  - JWT/SFTP secret 정책 변경

### 테스트/검증
- 자동 검증
  - `cd apps/backend && go test ./... -count=1` ✅
  - `docker run --rm -v "$PWD":/work -w /work/apps/backend golang:1.25.7 sh -lc 'export PATH=$PATH:/usr/local/go/bin; go test ./... -count=1'` ✅
- 수동 검증
  - release workflow 재트리거 필요(신규 태그 발행)

### 리스크 및 대응
- 잠재 리스크
  - prewarm 미호출 경로에서도 key 파일이 생성될 수 있음
- 대응
  - 기존 credential 데이터 존재 시 자동 생성 금지/복구 오류 유지로 데이터 복구 안전성 보존

### 롤백 방법
- PR revert 시 기존 strict prewarm-required 동작으로 복귀

### 리뷰 가이드
- 우선 확인 파일
  - `apps/backend/internal/account/service.go`
- 확인 포인트
  - 기존 credential 데이터가 있는 경우 복구 오류 전파가 유지되는지
  - required 모드에서 자동 bootstrap이 발생하지 않는지

### 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #185`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(불필요)
- [x] 브레이킹 변경 없음