### PR TITLE
fix: SMB 오류 해제 규칙과 관측 로그 필터 정합성 보강

### DIFF
--- a/apps/backend/internal/smb/service.go
+++ b/apps/backend/internal/smb/service.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/lteawoo/smb-core"
 	"github.com/rs/zerolog/log"
 	"taeu.kr/cohesion/internal/account"
 	"taeu.kr/cohesion/internal/config"
+	"taeu.kr/cohesion/internal/platform/logging"
 	"taeu.kr/cohesion/internal/space"
 )
 
@@ -28,8 +31,39 @@ type Service struct {
 	runtimeReady   bool
 	lastError      error
 	lastErrorStage FailureStage
+	lastErrorAt    time.Time
+	lastSuccessAt  time.Time
 	runtimeIssue   string
 	mu             sync.RWMutex
+}
+
+type coreTelemetry struct{}
+
+func (coreTelemetry) OnEvent(event smbcore.Event) {
+	stage := strings.TrimSpace(event.Stage)
+	if stage == "" {
+		stage = string(StageSession)
+	}
+	reason := strings.TrimSpace(event.Reason)
+	if reason == "" {
+		reason = ReasonRuntimeError
+	}
+
+	if event.Err != nil {
+		logging.Event(log.Warn(), logging.ComponentRuntime, "warn.smb.telemetry").
+			Str("service", "smb").
+			Str("stage", stage).
+			Str("reason", reason).
+			Err(event.Err).
+			Msg("[SMB] telemetry event")
+		return
+	}
+
+	logging.Event(log.Info(), logging.ComponentRuntime, "info.smb.telemetry").
+		Str("service", "smb").
+		Str("stage", stage).
+		Str("reason", reason).
+		Msg("[SMB] telemetry event")
 }
 
 func NewService(
@@ -65,7 +99,7 @@ func NewService(
 			MinDialect:   toCoreDialect(config.DefaultSMBMinVersion),
 			MaxDialect:   toCoreDialect(config.DefaultSMBMaxVersion),
 			RolloutPhase: smbcore.RolloutPhase(rolloutPhase),
-		}, authAdapter, authzAdapter, fsAdapter, nil)
+		}, authAdapter, authzAdapter, fsAdapter, coreTelemetry{})
 		if coreErr != nil {
 			log.Warn().
 				Err(coreErr).
@@ -113,6 +147,7 @@ func (s *Service) Start() error {
 		s.runtimeReady = false
 		s.lastError = err
 		s.lastErrorStage = StageBind
+		s.lastErrorAt = time.Now()
 		return fmt.Errorf("failed to start smb service on port %d: %w", s.port, err)
 	}
 
@@ -136,6 +171,8 @@ func (s *Service) Start() error {
 	}
 	s.lastError = nil
 	s.lastErrorStage = StageNone
+	s.lastErrorAt = time.Time{}
+	s.lastSuccessAt = time.Time{}
 	go s.acceptLoop(listener)
 	log.Info().
 		Int("port", s.port).
@@ -164,9 +201,11 @@ func (s *Service) acceptLoop(listener net.Listener) {
 			s.mu.Lock()
 			s.lastError = err
 			s.lastErrorStage = StageAccept
+			s.lastErrorAt = time.Now()
 			s.mu.Unlock()
 			continue
 		}
+		s.recordAcceptSuccess(time.Now())
 
 		if s.core == nil {
 			_ = conn.Close()
@@ -177,7 +216,12 @@ func (s *Service) acceptLoop(listener net.Listener) {
 }
 
 func (s *Service) handleConn(conn net.Conn) {
-	if err := s.core.HandleConn(context.Background(), conn); err != nil && !errors.Is(err, smbcore.ErrRuntimeNotImplemented) {
+	err := s.core.HandleConn(context.Background(), conn)
+	now := time.Now()
+	if err != nil {
+		if errors.Is(err, smbcore.ErrRuntimeNotImplemented) {
+			return
+		}
 		log.Warn().
 			Err(err).
 			Str("stage", string(StageSession)).
@@ -186,7 +230,30 @@ func (s *Service) handleConn(conn net.Conn) {
 		s.mu.Lock()
 		s.lastError = err
 		s.lastErrorStage = StageSession
+		s.lastErrorAt = now
 		s.mu.Unlock()
+		return
+	}
+
+	s.mu.Lock()
+	s.lastSuccessAt = now
+	if s.lastErrorStage == StageSession {
+		s.lastError = nil
+		s.lastErrorStage = StageNone
+		s.lastErrorAt = time.Time{}
+	}
+	s.mu.Unlock()
+}
+
+func (s *Service) recordAcceptSuccess(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.lastSuccessAt = now
+	if s.lastErrorStage == StageAccept {
+		s.lastError = nil
+		s.lastErrorStage = StageNone
+		s.lastErrorAt = time.Time{}
 	}
 }
 
@@ -213,6 +280,8 @@ func (s *Service) Stop() error {
 	s.runtimeReady = false
 	s.lastError = nil
 	s.lastErrorStage = StageNone
+	s.lastErrorAt = time.Time{}
+	s.lastSuccessAt = time.Time{}
 	s.runtimeIssue = ""
 	log.Info().Msg("[SMB] service stopped")
 	return nil
@@ -262,9 +331,18 @@ func (s *Service) Readiness() Readiness {
 
 	if s.lastError != nil {
 		metadata.State = StateUnhealthy
-		metadata.Reason = ReasonRuntimeError
 		metadata.Stage = s.lastErrorStage
-		metadata.Message = "SMB 런타임 오류"
+		switch s.lastErrorStage {
+		case StageBind:
+			metadata.Reason = ReasonBindNotReady
+			metadata.Message = "SMB 바인드 준비 안됨"
+		case StageAccept:
+			metadata.Reason = ReasonAcceptFailed
+			metadata.Message = "SMB 연결 수락 오류"
+		default:
+			metadata.Reason = ReasonRuntimeError
+			metadata.Message = "SMB 런타임 오류"
+		}
 		return metadata
 	}
 

--- a/apps/backend/internal/smb/service_test.go
+++ b/apps/backend/internal/smb/service_test.go
@@ -1,10 +1,18 @@
 package smb
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/lteawoo/smb-core"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 func TestService_StartStop_Disabled(t *testing.T) {
@@ -82,8 +90,8 @@ func TestService_StartFailure_UpdatesReadiness(t *testing.T) {
 	if readiness.Stage != StageBind {
 		t.Fatalf("expected bind stage, got %q", readiness.Stage)
 	}
-	if readiness.Reason != ReasonRuntimeError {
-		t.Fatalf("expected runtime_error reason, got %q", readiness.Reason)
+	if readiness.Reason != ReasonBindNotReady {
+		t.Fatalf("expected bind_not_ready reason, got %q", readiness.Reason)
 	}
 }
 
@@ -156,4 +164,163 @@ func waitDial(addr string, timeout time.Duration) error {
 
 func toPortString(port int) string {
 	return strconv.Itoa(port)
+}
+
+func TestCoreTelemetry_LogsDenyReasonsWithoutMutation(t *testing.T) {
+	var buffer bytes.Buffer
+	previousLogger := log.Logger
+	log.Logger = zerolog.New(&buffer).With().Timestamp().Logger()
+	defer func() {
+		log.Logger = previousLogger
+	}()
+
+	telemetry := coreTelemetry{}
+	reasons := []string{
+		smbcore.DenyReasonReadonlyPhaseDenied,
+		smbcore.DenyReasonPermissionDenied,
+		smbcore.DenyReasonPathBoundary,
+	}
+
+	for _, reason := range reasons {
+		telemetry.OnEvent(smbcore.Event{
+			Stage:  "policy",
+			Reason: reason,
+		})
+	}
+
+	logs := buffer.String()
+	for _, reason := range reasons {
+		if !strings.Contains(logs, `"`+reason+`"`) {
+			t.Fatalf("expected telemetry log to preserve reason %q, logs=%s", reason, logs)
+		}
+	}
+	if !strings.Contains(logs, `"service":"smb"`) {
+		t.Fatalf("expected telemetry log to include service=smb, logs=%s", logs)
+	}
+}
+
+func TestService_HandleConn_ClearsSessionRuntimeErrorAfterSuccessfulSession(t *testing.T) {
+	runtime := &fakeRuntime{
+		errs: []error{
+			errors.New("forced session error"),
+			nil,
+		},
+	}
+	svc := &Service{
+		enabled:      true,
+		running:      true,
+		bindReady:    true,
+		runtimeReady: true,
+		port:         445,
+		rolloutPhase: "readonly",
+		core:         runtime,
+	}
+
+	firstClient, firstServer := net.Pipe()
+	defer firstClient.Close()
+	svc.handleConn(firstServer)
+
+	firstReadiness := svc.Readiness()
+	if firstReadiness.Reason != ReasonRuntimeError {
+		t.Fatalf("expected runtime_error after failed session, got %q", firstReadiness.Reason)
+	}
+
+	secondClient, secondServer := net.Pipe()
+	defer secondClient.Close()
+	svc.handleConn(secondServer)
+
+	secondReadiness := svc.Readiness()
+	if secondReadiness.State != StateHealthy {
+		t.Fatalf("expected healthy state after successful session, got %q", secondReadiness.State)
+	}
+	if secondReadiness.Reason != ReasonReady {
+		t.Fatalf("expected ready reason after successful session, got %q", secondReadiness.Reason)
+	}
+}
+
+func TestService_HandleConn_RuntimeNotImplementedDoesNotClearPreviousSessionError(t *testing.T) {
+	runtime := &fakeRuntime{
+		errs: []error{
+			errors.New("forced session error"),
+			smbcore.ErrRuntimeNotImplemented,
+		},
+	}
+	svc := &Service{
+		enabled:      true,
+		running:      true,
+		bindReady:    true,
+		runtimeReady: true,
+		port:         445,
+		rolloutPhase: "readonly",
+		core:         runtime,
+	}
+
+	firstClient, firstServer := net.Pipe()
+	defer firstClient.Close()
+	svc.handleConn(firstServer)
+
+	firstReadiness := svc.Readiness()
+	if firstReadiness.Reason != ReasonRuntimeError {
+		t.Fatalf("expected runtime_error after first failed session, got %q", firstReadiness.Reason)
+	}
+
+	secondClient, secondServer := net.Pipe()
+	defer secondClient.Close()
+	svc.handleConn(secondServer)
+
+	secondReadiness := svc.Readiness()
+	if secondReadiness.Reason != ReasonRuntimeError {
+		t.Fatalf("expected runtime_error to remain after runtime_not_implemented, got %q", secondReadiness.Reason)
+	}
+}
+
+func TestService_RecordAcceptSuccess_ClearsAcceptFailedState(t *testing.T) {
+	svc := &Service{
+		enabled:        true,
+		running:        true,
+		bindReady:      true,
+		runtimeReady:   true,
+		port:           445,
+		rolloutPhase:   "readonly",
+		lastError:      errors.New("forced accept error"),
+		lastErrorStage: StageAccept,
+		lastErrorAt:    time.Now(),
+	}
+
+	svc.recordAcceptSuccess(time.Now())
+
+	readiness := svc.Readiness()
+	if readiness.State != StateHealthy {
+		t.Fatalf("expected healthy state after accept recovery, got %q", readiness.State)
+	}
+	if readiness.Reason != ReasonReady {
+		t.Fatalf("expected ready reason after accept recovery, got %q", readiness.Reason)
+	}
+}
+
+type fakeRuntime struct {
+	errs  []error
+	index int
+}
+
+func (f *fakeRuntime) HandleConn(_ context.Context, conn net.Conn) error {
+	_ = conn.Close()
+	if f.index >= len(f.errs) {
+		return nil
+	}
+	err := f.errs[f.index]
+	f.index++
+	return err
+}
+
+func (f *fakeRuntime) Supports(_ smbcore.Dialect) bool {
+	return true
+}
+
+func (f *fakeRuntime) IsReadOnly() bool {
+	return true
+}
+
+func (f *fakeRuntime) Phase() smbcore.RolloutPhase {
+	return smbcore.RolloutPhaseReadOnly
 }

--- a/apps/backend/internal/status/handler_test.go
+++ b/apps/backend/internal/status/handler_test.go
@@ -208,3 +208,57 @@ func TestHandleStatus_UsesSMBReadinessProviderState(t *testing.T) {
 		t.Fatal("expected runtimeReady=false")
 	}
 }
+
+func TestHandleStatus_PropagatesSMBRuntimeStageReason(t *testing.T) {
+	originalConf := config.Conf
+	defer func() { config.Conf = originalConf }()
+
+	config.Conf.Server.WebdavEnabled = true
+	config.Conf.Server.FtpEnabled = false
+	config.Conf.Server.SftpEnabled = false
+	config.Conf.Server.SmbEnabled = true
+	config.Conf.Server.SmbPort = 1445
+	config.Conf.Server.SmbRolloutPhase = config.SMBRolloutPhaseReadOnly
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	spaceService := space.NewService(&statusTestSpaceStore{})
+	handler := NewHandler(db, spaceService, statusTestSMBReadiness{
+		readiness: smb.Readiness{
+			State:        smb.StateUnhealthy,
+			Reason:       smb.ReasonAcceptFailed,
+			Message:      "SMB 연결 수락 오류",
+			Stage:        smb.StageAccept,
+			RolloutPhase: config.SMBRolloutPhaseReadOnly,
+			PolicySource: "config",
+			BindReady:    true,
+			RuntimeReady: true,
+		},
+	}, "3000")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	recorder := httptest.NewRecorder()
+
+	if webErr := handler.handleStatus(recorder, req); webErr != nil {
+		t.Fatalf("handleStatus returned error: %+v", webErr)
+	}
+
+	var resp StatusResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Protocols["smb"].Status != "unhealthy" {
+		t.Fatalf("expected smb unhealthy, got %q", resp.Protocols["smb"].Status)
+	}
+	if resp.Protocols["smb"].Reason != smb.ReasonAcceptFailed {
+		t.Fatalf("expected smb reason %q, got %q", smb.ReasonAcceptFailed, resp.Protocols["smb"].Reason)
+	}
+	if resp.Protocols["smb"].Message != "SMB 연결 수락 오류" {
+		t.Fatalf("unexpected smb message: %q", resp.Protocols["smb"].Message)
+	}
+}

--- a/apps/frontend/src/components/layout/MainLayout/ServerStatus.test.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/ServerStatus.test.tsx
@@ -72,10 +72,11 @@ vi.mock('antd', () => ({
 }));
 
 describe('ServerStatus', () => {
-  it('renders SMB status metadata in popover content', () => {
+  it('renders SMB status as binary availability in popover content', () => {
     const view = render(<ServerStatus />);
 
     expect(view.getByText('SMB')).toBeTruthy();
-    expect(view.getByText(/direct, phase:readonly, policy:config, bind:ready, runtime:ready, 2.1-3.1.1/)).toBeTruthy();
+    expect(view.getByText('serverStatus.availability.available')).toBeTruthy();
+    expect(view.queryByText(/direct, phase:readonly, policy:config, bind:ready, runtime:ready, 2.1-3.1.1/)).toBeNull();
   });
 });

--- a/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
@@ -60,6 +60,13 @@ function getStatusLabel(status: ProtocolStatus['status'] | string, t: (key: stri
   }
 }
 
+function getAvailabilityLabel(status: ProtocolStatus['status'] | string, t: (key: string) => unknown) {
+  if (status === 'healthy') {
+    return String(t('serverStatus.availability.available'));
+  }
+  return String(t('serverStatus.availability.unavailable'));
+}
+
 function normalizeProtocolPath(path?: string) {
   if (!path) {
     return '';
@@ -182,19 +189,9 @@ function PopoverContent({
       {orderedProtocolEntries.map(([key, proto]) => {
         const displayPort = key === 'http' ? webPort : proto.port;
         const displayPath = normalizeProtocolPath(proto.path);
-        const smbMeta = key === 'smb'
-          ? [
-            proto.endpointMode,
-            proto.rolloutPhase ? `phase:${proto.rolloutPhase}` : '',
-            proto.policySource ? `policy:${proto.policySource}` : '',
-            proto.bindReady === undefined ? '' : `bind:${proto.bindReady ? 'ready' : 'not-ready'}`,
-            proto.runtimeReady === undefined ? '' : `runtime:${proto.runtimeReady ? 'ready' : 'not-ready'}`,
-            proto.minVersion && proto.maxVersion ? `${proto.minVersion}-${proto.maxVersion}` : '',
-          ]
-            .filter(Boolean)
-            .join(', ')
-          : '';
-        const detailMessage = proto.reason ? `${proto.message} (${proto.reason})` : proto.message;
+        const isSmb = key === 'smb';
+        const detailMessage = isSmb ? '' : (proto.reason ? `${proto.message} (${proto.reason})` : proto.message);
+        const statusLabel = isSmb ? getAvailabilityLabel(proto.status, t) : getStatusLabel(proto.status, t);
 
         return (
           <div
@@ -215,12 +212,12 @@ function PopoverContent({
                 <span style={{ fontSize: 13 }}>{PROTOCOL_LABELS[key] || key}</span>
                 {displayPort && (
                   <span style={{ fontSize: 11, color: token.colorTextTertiary }}>
-                    :{displayPort}{displayPath}{smbMeta ? ` (${smbMeta})` : ''}
+                    :{displayPort}{displayPath}
                   </span>
                 )}
               </div>
               <span style={{ fontSize: 12, color: token.colorTextSecondary }}>
-                {getStatusLabel(proto.status, t)}
+                {statusLabel}
               </span>
             </div>
             {detailMessage && (

--- a/apps/frontend/src/i18n/resources.ts
+++ b/apps/frontend/src/i18n/resources.ts
@@ -41,7 +41,10 @@ export const koTranslations = {
     hostCopied: "호스트 주소를 복사했습니다",
     hostCopyFailed: "주소 복사에 실패했습니다",
     connectionUnavailable: "서버에 연결할 수 없습니다",
-    smbReadOnlyPrefix: "read-only",
+    availability: {
+      available: "됨",
+      unavailable: "안됨",
+    },
     status: {
       healthy: "정상",
       unhealthy: "오류",
@@ -615,7 +618,10 @@ export const enTranslations = {
     hostCopied: "Host address copied",
     hostCopyFailed: "Failed to copy address",
     connectionUnavailable: "Cannot connect to server",
-    smbReadOnlyPrefix: "read-only",
+    availability: {
+      available: "Available",
+      unavailable: "Unavailable",
+    },
     status: {
       healthy: "Healthy",
       unhealthy: "Error",

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -209,6 +209,12 @@ rg "event=http\\.access .*path=/api/system/restart" logs/access.log
 
 # updater 런타임 오류 확인
 rg "event=error\\.updater\\." logs/updater.log
+
+# SMB telemetry/런타임 원인 확인(필드 순서 무관)
+rg "service=smb" logs/app.log | rg "stage=" | rg "reason="
+
+# SMB deny taxonomy 확인(필드 순서 무관)
+rg "service=smb" logs/app.log | rg "reason=(readonly_phase_denied|permission_denied|path_boundary_violation)"
 ```
 
 ### 운영자 확인 순서

--- a/docs/smb-rollout-playbook.md
+++ b/docs/smb-rollout-playbook.md
@@ -38,6 +38,15 @@ SMB를 기존 WEB/WebDAV/FTP/SFTP 운영 패턴과 일관되게 단계 도입하
 - `runtime_not_ready`: 바인드는 됐지만 프로토콜 세션 처리 준비 미완료
 - `runtime_error`: 런타임 내부 오류
 
+### 상태 채널 분리 원칙
+
+- 사용자 채널(상태 팝오버):
+  - SMB는 `됨/안됨` 이진 상태로만 표시한다.
+  - 운영 진단 필드(`reason`, `stage`, `bindReady`, `runtimeReady`, phase metadata)는 노출하지 않는다.
+- 운영 채널(`/api/status`, `app.log`):
+  - 진단 필드(`reason`, `stage`, taxonomy)는 유지한다.
+  - 장애 분석은 운영 채널 기준으로 수행한다.
+
 ### 연산 허용/거부 매트릭스
 
 | 연산 | readonly | write-safe | write-full | 비고 |
@@ -145,3 +154,16 @@ SMB를 기존 WEB/WebDAV/FTP/SFTP 운영 패턴과 일관되게 단계 도입하
 - `/api/status`가 `runtime_not_ready`면 SMB 런타임 준비 상태를 먼저 복구하고 재시작
 - write/manage 요청 거부는 rollout phase 기준 정상 동작일 수 있으므로 현재 `rolloutPhase`와 기대 시나리오를 우선 대조
 - 권한 이상: 계정/Space 권한 매핑(`CanAccessSpaceByID`)과 사용자 권한 데이터 재검증
+
+### SMB 로그 점검 예시
+
+```bash
+# SMB telemetry/런타임 이벤트 확인(필드 순서 무관)
+rg "service=smb" logs/app.log | rg "stage=" | rg "reason="
+
+# 정책 거부 taxonomy 확인(필드 순서 무관)
+rg "service=smb" logs/app.log | rg "reason=(readonly_phase_denied|permission_denied|path_boundary_violation)"
+
+# 런타임 세션 오류 확인
+rg "service=smb" logs/app.log | rg "reason=runtime_error"
+```


### PR DESCRIPTION
## 요약
SMB 상태가 일시 오류 이후에도 `accept_failed`로 고착되거나, `ErrRuntimeNotImplemented`에서 과도하게 복구되는 리스크를 제거했습니다. 운영 문서의 로그 검색 패턴도 실제 로그 포맷(필드 순서 비고정)과 맞게 정정했습니다.

## 관련 이슈
Closes #187

## 변경 사항
- Backend (`internal/smb/service`)
  - accept 성공 시 `StageAccept` 오류 해제 경로(`recordAcceptSuccess`) 추가
  - session 오류 해제를 `err == nil` 성공 이벤트로 제한
  - `ErrRuntimeNotImplemented`는 상태 해제 트리거에서 제외
  - telemetry sink 연결 및 stage/reason 구조화 로깅 유지
- Tests
  - `ErrRuntimeNotImplemented` 시 이전 `runtime_error` 유지 회귀 테스트 추가
  - accept 복구 시 상태 정상화 회귀 테스트 추가
  - status 핸들러의 SMB reason/message 전파 테스트 보강
- Frontend
  - SMB 상태 팝오버를 사용자용 이진 상태(`available/unavailable`)로 단순화
- Docs
  - `docs/backend.md`, `docs/smb-rollout-playbook.md`의 SMB 로그 필터를 필드 순서 비의존 패턴으로 정정

## 범위
### In Scope
- SMB 오류 상태 해제 규칙 보강
- SMB observability/상태 표면 단순화 반영
- 회귀 테스트 및 운영 문서 보강

### Out of Scope
- SMB 인증/권한 정책 변경
- rollout phase 정책 변경
- 릴리즈 파이프라인 구조 변경

## 테스트/검증
- `cd apps/backend && go test ./internal/smb ./internal/status -count=1` ✅
- `cd apps/frontend && pnpm test -- ServerStatus` ✅
- `cd apps/frontend && pnpm typecheck` ✅

## 리스크 및 대응
- 리스크: 상태 해제 조건 변경으로 장애 은닉 가능성
- 대응: `ErrRuntimeNotImplemented` 제외 테스트 추가, accept 복구 테스트 추가로 회귀 방지
- 롤백: PR revert 시 기존 상태 계산/문서 패턴으로 즉시 복구 가능

## 리뷰 가이드
1. `apps/backend/internal/smb/service.go`
2. `apps/backend/internal/smb/service_test.go`
3. `apps/backend/internal/status/handler_test.go`
4. `apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx`
5. `docs/smb-rollout-playbook.md`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #187`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음