### PR TITLE
fix: 서버 상태 팝오버를 정상/중지 라벨로 단순화

### DIFF
--- a/apps/frontend/src/components/layout/MainLayout/ServerStatus.test.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/ServerStatus.test.tsx
@@ -72,11 +72,12 @@ vi.mock('antd', () => ({
 }));
 
 describe('ServerStatus', () => {
-  it('renders SMB status as binary availability in popover content', () => {
+  it('renders protocol status as binary normal/stopped without detail message', () => {
     const view = render(<ServerStatus />);
 
     expect(view.getByText('SMB')).toBeTruthy();
-    expect(view.getByText('serverStatus.availability.available')).toBeTruthy();
+    expect(view.getAllByText('serverStatus.binaryStatus.normal').length).toBeGreaterThanOrEqual(2);
+    expect(view.queryByText('ok')).toBeNull();
     expect(view.queryByText(/direct, phase:readonly, policy:config, bind:ready, runtime:ready, 2.1-3.1.1/)).toBeNull();
   });
 });

--- a/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
+++ b/apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx
@@ -47,24 +47,11 @@ function getStatusColor(
   }
 }
 
-function getStatusLabel(status: ProtocolStatus['status'] | string, t: (key: string) => unknown) {
-  switch (status) {
-    case 'healthy':
-      return String(t('serverStatus.status.healthy'));
-    case 'unhealthy':
-      return String(t('serverStatus.status.unhealthy'));
-    case 'unavailable':
-      return String(t('serverStatus.status.unavailable'));
-    default:
-      return String(t('serverStatus.status.unavailable'));
-  }
-}
-
-function getAvailabilityLabel(status: ProtocolStatus['status'] | string, t: (key: string) => unknown) {
+function getSimpleStatusLabel(status: ProtocolStatus['status'] | string, t: (key: string) => unknown) {
   if (status === 'healthy') {
-    return String(t('serverStatus.availability.available'));
+    return String(t('serverStatus.binaryStatus.normal'));
   }
-  return String(t('serverStatus.availability.unavailable'));
+  return String(t('serverStatus.binaryStatus.stopped'));
 }
 
 function normalizeProtocolPath(path?: string) {
@@ -189,9 +176,7 @@ function PopoverContent({
       {orderedProtocolEntries.map(([key, proto]) => {
         const displayPort = key === 'http' ? webPort : proto.port;
         const displayPath = normalizeProtocolPath(proto.path);
-        const isSmb = key === 'smb';
-        const detailMessage = isSmb ? '' : (proto.reason ? `${proto.message} (${proto.reason})` : proto.message);
-        const statusLabel = isSmb ? getAvailabilityLabel(proto.status, t) : getStatusLabel(proto.status, t);
+        const statusLabel = getSimpleStatusLabel(proto.status, t);
 
         return (
           <div
@@ -220,11 +205,6 @@ function PopoverContent({
                 {statusLabel}
               </span>
             </div>
-            {detailMessage && (
-              <div style={{ marginTop: 2, marginLeft: 16, fontSize: 11, color: token.colorTextTertiary }}>
-                {detailMessage}
-              </div>
-            )}
           </div>
         );
       })}

--- a/apps/frontend/src/i18n/resources.ts
+++ b/apps/frontend/src/i18n/resources.ts
@@ -41,9 +41,9 @@ export const koTranslations = {
     hostCopied: "호스트 주소를 복사했습니다",
     hostCopyFailed: "주소 복사에 실패했습니다",
     connectionUnavailable: "서버에 연결할 수 없습니다",
-    availability: {
-      available: "됨",
-      unavailable: "안됨",
+    binaryStatus: {
+      normal: "정상",
+      stopped: "중지",
     },
     status: {
       healthy: "정상",
@@ -618,9 +618,9 @@ export const enTranslations = {
     hostCopied: "Host address copied",
     hostCopyFailed: "Failed to copy address",
     connectionUnavailable: "Cannot connect to server",
-    availability: {
-      available: "Available",
-      unavailable: "Unavailable",
+    binaryStatus: {
+      normal: "Normal",
+      stopped: "Stopped",
     },
     status: {
       healthy: "Healthy",


### PR DESCRIPTION
## 요약
사용자 상태 팝오버를 빠른 확인용으로 단순화했습니다. 프로토콜 상태 라벨을 `정상/중지` 이진값으로 통일하고, 라벨 하단의 상세 상태 문구 노출을 제거했습니다.

## 관련 이슈
Closes #189

## 변경 사항
- `ServerStatus.tsx`
  - 상태 라벨 계산을 `binaryStatus(normal/stopped)` 키 기반 공통 함수로 정리
  - 상태 라벨 하단 상세 문구(`message/reason`) 렌더링 제거
- `resources.ts`
  - `serverStatus.availability` 키를 `serverStatus.binaryStatus`로 전환(ko/en)
- `ServerStatus.test.tsx`
  - 새 정책(정상/중지 라벨, 상세 문구 미노출) 기준으로 테스트 갱신

## 범위
### In Scope
- 상태 팝오버 라벨 단순화
- i18n 키 정리
- 관련 프론트 테스트 갱신

### Out of Scope
- 백엔드 `/api/status` 응답 스키마 변경
- 운영 진단 로그 정책 변경

## 테스트/검증
- `cd apps/frontend && pnpm test -- ServerStatus` ✅
- `cd apps/frontend && pnpm typecheck` ✅

## 리스크 및 대응
- 리스크: 기존 번역 키 참조 누락 가능성
- 대응: 사용 경로 검색 및 `ServerStatus` 테스트 갱신으로 회귀 방지
- 롤백: PR revert 시 기존 라벨/상세 문구 정책으로 즉시 복구 가능

## 리뷰 가이드
1. `apps/frontend/src/components/layout/MainLayout/ServerStatus.tsx`
2. `apps/frontend/src/i18n/resources.ts`
3. `apps/frontend/src/components/layout/MainLayout/ServerStatus.test.tsx`

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #189`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음