### PR TITLE
docs: README에 업데이트 경로와 안내 위치 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ Then open `http://localhost:3000`.
 3. Run `cohesion` on macOS/Linux or `cohesion.exe` on Windows.
 4. Open `http://localhost:3000` in your browser.
 
+## Updating
+
+### Homebrew Install
+
+Use Homebrew to update Cohesion:
+
+```bash
+brew update
+brew upgrade cohesion
+```
+
+Homebrew installs do not support in-app self-update.
+In the app, update guidance appears in `Settings > About`.
+
+### Direct Release Install
+
+- macOS: Download and reinstall the latest release package from [GitHub Releases](https://github.com/lteawoo/Cohesion/releases).
+- Linux: Use the in-app update flow when available, or replace the binary with the latest release package.
+- Windows: Use the in-app update flow when available, or replace the binary with the latest release package.
+
 ## First Time Setup
 
 1. Open Cohesion in your browser.


### PR DESCRIPTION
## 요약
문제:
루트 README에는 설치 방법은 있었지만 Homebrew/direct release 설치본의 업데이트 경로와 앱 내 안내 위치가 정리되어 있지 않았습니다.

해결:
README에 `Updating` 섹션을 추가해 Homebrew 업데이트 명령, Homebrew 설치본의 앱 내 self-update 미지원, 그리고 앱 내 안내 위치 `Settings > About`를 명시했습니다. direct release 설치본의 플랫폼별 업데이트 경로도 함께 정리했습니다.

기대 효과:
사용자가 README만 읽어도 설치 채널별 업데이트 방법과 앱 내 안내 위치를 바로 이해할 수 있습니다.

## 관련 이슈
Closes #255

## 변경 사항
- `README.md`에 `Updating` 섹션 추가
- Homebrew 설치본의 업데이트 명령 `brew update`, `brew upgrade cohesion` 명시
- Homebrew 설치본의 앱 내 안내 위치 `Settings > About` 추가
- direct release 설치본의 macOS/Linux/Windows 업데이트 경로 정리

## 범위
In Scope
- 루트 README 업데이트 경로 문서화
- 설치 채널별 안내 문구 정리

Out of Scope
- 업데이트 로직 변경
- Settings UI 변경
- Homebrew tap 배포 자동화 변경

## 테스트/검증
- 자동 검증: 없음
- 수동 검증:
  - README 문구와 앱의 `Settings > About` 업데이트 안내 흐름 대조
  - Homebrew 설치본은 앱 내 self-update 미지원, direct release 설치본은 플랫폼별 수동/앱 내 업데이트 경로를 README에서 확인
- 결과: PASS

## 리스크 및 대응
- 잠재 리스크: README 문구가 실제 앱 동작과 어긋날 수 있음
- 대응: 현재 `Settings > About` 분기와 설치 채널별 업데이트 정책을 코드 기준으로 대조해 문구를 맞춤
- 롤백: PR revert로 README 변경만 되돌리면 됨

## 리뷰 가이드
- 먼저 볼 파일: `README.md`
- 확인 포인트: Homebrew/direct release 업데이트 안내가 현재 앱 동작과 일치하는지

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`chore`)
- [x] 관련 이슈 링크 확인 (`Closes #255`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음