### PR TITLE
fix: frontend lint와 타입체크 기준선 복구

### DIFF
--- a/apps/frontend/src/features/browse/components/FolderContent.test.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent.test.tsx
@@ -43,7 +43,7 @@ const h = vi.hoisted(() => {
     selectedSpace,
     content: contentItems,
     isLoading: false,
-    error: null,
+    error: null as Error | null,
     setPath: mockSetPath,
     fetchSpaceContents: mockFetchSpaceContents,
     trashOpenRequest: null,

--- a/apps/frontend/src/features/browse/components/FolderContent/TrashModal.tsx
+++ b/apps/frontend/src/features/browse/components/FolderContent/TrashModal.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 import { Modal, Table, Space as AntSpace, Button, Empty } from 'antd';
 import type { TableColumnsType } from 'antd';
 import { DeleteOutlined, RollbackOutlined, FolderFilled, FileOutlined } from '@ant-design/icons';
-import type { TrashItem } from '../../hooks/useFileOperations';
 import { formatDate, formatSize } from '../../constants';
+import type { TrashItem } from '../../hooks/transferOperationsShared';
 import { useTranslation } from 'react-i18next';
 
 interface TrashModalProps {

--- a/apps/frontend/src/features/browse/hooks/useArchiveTransfers.ts
+++ b/apps/frontend/src/features/browse/hooks/useArchiveTransfers.ts
@@ -276,7 +276,7 @@ export function useArchiveTransfers({
     });
   }, [driveArchiveDownloadFlow, readErrorMessage, setArchiveTransferStatus, t]);
 
-  const pumpArchiveQueue = useCallback(() => {
+  const pumpArchiveQueue = useCallback(function pumpArchiveQueue() {
     while (activeArchiveTaskCountRef.current < MAX_ACTIVE_ARCHIVE_TASKS && archiveQueueRef.current.length > 0) {
       const nextTask = archiveQueueRef.current.shift();
       if (!nextTask) {

--- a/apps/frontend/src/features/browse/hooks/useDirectDownloadTransfers.ts
+++ b/apps/frontend/src/features/browse/hooks/useDirectDownloadTransfers.ts
@@ -7,7 +7,6 @@ import {
   normalizeRelativePath,
   triggerBrowserDownloadFromUrl,
   type DownloadTicketResponse,
-  type TransferMessageApi,
   type Translate,
 } from './transferOperationsShared';
 

--- a/apps/frontend/src/features/browse/hooks/useFileOperations.test.tsx
+++ b/apps/frontend/src/features/browse/hooks/useFileOperations.test.tsx
@@ -937,8 +937,10 @@ describe('useFileOperations transfer states', () => {
       throw new Error('delete confirm handler was not registered');
     }
 
+    const onOk = confirmConfig.onOk;
+
     await act(async () => {
-      await confirmConfig.onOk();
+      await onOk();
     });
 
     expect(h.message.error).toHaveBeenCalledWith('fileOperations.moveToTrashFailed');

--- a/apps/frontend/src/features/browse/hooks/useFileOperations.tsx
+++ b/apps/frontend/src/features/browse/hooks/useFileOperations.tsx
@@ -23,6 +23,7 @@ import {
   type TransferMode,
   type TransferOperationResult,
   type TransferResponsePayload,
+  type TransferSummary,
   type TrashConflictPolicy,
   type TrashDeleteResponsePayload,
   type TrashEmptyResponsePayload,
@@ -661,7 +662,7 @@ export function useFileOperations(selectedPath: string, selectedSpace?: Space): 
         message.error(error instanceof Error ? error.message : t('fileOperations.renameFailed'));
       }
     },
-    [selectedSpace, refreshContents, message, invalidateTree, t]
+    [selectedSpace, refreshContents, message, invalidateTree, readErrorMessage, t]
   );
 
   // 새 폴더 만들기 처리
@@ -698,7 +699,7 @@ export function useFileOperations(selectedPath: string, selectedSpace?: Space): 
         message.error(error instanceof Error ? error.message : t('fileOperations.createFolderFailed'));
       }
     },
-    [selectedSpace, refreshContents, message, invalidateTree, t]
+    [selectedSpace, refreshContents, message, invalidateTree, readErrorMessage, t]
   );
 
   // 다중 휴지통 이동 처리
@@ -748,7 +749,7 @@ export function useFileOperations(selectedPath: string, selectedSpace?: Space): 
         },
       });
     },
-    [selectedSpace, refreshContents, message, modal, invalidateTree, t]
+    [selectedSpace, refreshContents, message, modal, invalidateTree, readErrorMessage, t]
   );
 
   const fetchTrashItems = useCallback(async (): Promise<TrashItem[]> => {
@@ -1052,7 +1053,7 @@ export function useFileOperations(selectedPath: string, selectedSpace?: Space): 
         },
       });
     },
-    [selectedSpace, refreshContents, message, modal, invalidateTree, t]
+    [selectedSpace, refreshContents, message, modal, invalidateTree, readErrorMessage, t]
   );
 
   return {

--- a/apps/frontend/src/features/browse/hooks/useTrashModalManager.ts
+++ b/apps/frontend/src/features/browse/hooks/useTrashModalManager.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { App } from 'antd';
 import type { Space } from '@/features/space/types';
-import type { TrashItem } from './useFileOperations';
+import type { TrashItem } from './transferOperationsShared';
 import { useTranslation } from 'react-i18next';
 
 interface TrashOpenRequest {

--- a/apps/frontend/src/features/browse/hooks/useUploadTransfers.ts
+++ b/apps/frontend/src/features/browse/hooks/useUploadTransfers.ts
@@ -248,7 +248,7 @@ export function useUploadTransfers({
     return results;
   }, [performUpload, promptConflictPolicy, setUploadTransferStatus, t]);
 
-  const pumpUploadQueue = useCallback(() => {
+  const pumpUploadQueue = useCallback(function pumpUploadQueue() {
     while (activeUploadBatchCountRef.current < MAX_ACTIVE_UPLOAD_BATCHES && uploadBatchQueueRef.current.length > 0) {
       const nextBatch = uploadBatchQueueRef.current.shift();
       if (!nextBatch) {

--- a/apps/frontend/src/features/space/components/DirectorySetupModal.test.tsx
+++ b/apps/frontend/src/features/space/components/DirectorySetupModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ChangeEvent, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -139,42 +139,37 @@ describe('DirectorySetupModal', () => {
   it('enables creation after a selected root validates successfully', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    render(<DirectorySetupModal isOpen={true} onClose={onClose} />);
+    const view = render(<DirectorySetupModal isOpen={true} onClose={onClose} />);
 
-    await user.click(screen.getByRole('button', { name: 'select-valid' }));
+    await user.click(view.getByRole('button', { name: 'select-valid' }));
 
-    await waitFor(() => {
-      expect(h.storeState.validateSpaceRoot).toHaveBeenCalledWith('/valid');
-    });
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('valid')).not.toBeNull();
-    });
-    expect(screen.getByText('directorySetup.validation.valid')).not.toBeNull();
+    await view.findByText('directorySetup.validation.valid');
+    expect(h.storeState.validateSpaceRoot).toHaveBeenCalledWith('/valid');
+    expect(view.getByDisplayValue('valid')).not.toBeNull();
+    expect(view.getByText('directorySetup.validation.valid')).not.toBeNull();
 
-    const okButton = screen.getByRole('button', { name: 'ok' });
+    const okButton = view.getByRole('button', { name: 'ok' });
     expect(okButton).toHaveProperty('disabled', false);
 
     await user.click(okButton);
 
-    await waitFor(() => {
-      expect(h.storeState.createSpace).toHaveBeenCalledWith('valid', '/valid');
-    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(h.storeState.createSpace).toHaveBeenCalledWith('valid', '/valid');
     expect(h.messageApi.success).toHaveBeenCalledWith('directorySetup.createSuccess');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('blocks submit and shows permission guidance when the selected root is unreadable', async () => {
     const user = userEvent.setup();
-    render(<DirectorySetupModal isOpen={true} onClose={vi.fn()} />);
+    const view = render(<DirectorySetupModal isOpen={true} onClose={vi.fn()} />);
 
-    await user.click(screen.getByRole('button', { name: 'select-denied' }));
+    await user.click(view.getByRole('button', { name: 'select-denied' }));
 
-    await waitFor(() => {
-      expect(h.storeState.validateSpaceRoot).toHaveBeenCalledWith('/denied');
-    });
-    expect(screen.getByText('directorySetup.validation.permissionDenied')).not.toBeNull();
-    expect(screen.getByText('directorySetup.validation.permissionDeniedHint')).not.toBeNull();
-    expect(screen.getByRole('button', { name: 'ok' })).toHaveProperty('disabled', true);
+    await view.findByText('directorySetup.validation.permissionDenied');
+    expect(h.storeState.validateSpaceRoot).toHaveBeenCalledWith('/denied');
+    expect(view.getByText('directorySetup.validation.permissionDenied')).not.toBeNull();
+    expect(view.getByText('directorySetup.validation.permissionDeniedHint')).not.toBeNull();
+    expect(view.getByRole('button', { name: 'ok' })).toHaveProperty('disabled', true);
     expect(h.storeState.createSpace).not.toHaveBeenCalled();
   });
 
@@ -188,23 +183,20 @@ describe('DirectorySetupModal', () => {
       })
     );
 
-    render(<DirectorySetupModal isOpen={true} onClose={onClose} />);
+    const view = render(<DirectorySetupModal isOpen={true} onClose={onClose} />);
 
-    await user.click(screen.getByRole('button', { name: 'select-valid' }));
+    await user.click(view.getByRole('button', { name: 'select-valid' }));
 
-    const okButton = await screen.findByRole('button', { name: 'ok' });
-    await waitFor(() => {
-      expect(okButton).toHaveProperty('disabled', false);
-    });
+    const okButton = await view.findByRole('button', { name: 'ok' });
+    expect(okButton).toHaveProperty('disabled', false);
 
     await user.click(okButton);
 
-    await waitFor(() => {
-      expect(h.storeState.createSpace).toHaveBeenCalledWith('valid', '/valid');
-    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(h.storeState.createSpace).toHaveBeenCalledWith('valid', '/valid');
     expect(h.messageApi.error).toHaveBeenCalledWith('directorySetup.validation.permissionDenied');
     expect(onClose).not.toHaveBeenCalled();
-    expect(screen.getByText('directorySetup.title')).not.toBeNull();
-    expect(screen.getByText('directorySetup.validation.permissionDeniedHint')).not.toBeNull();
+    expect(view.getByText('directorySetup.title')).not.toBeNull();
+    expect(view.getByText('directorySetup.validation.permissionDeniedHint')).not.toBeNull();
   });
 });

--- a/apps/frontend/src/features/space/components/DirectorySetupModal.tsx
+++ b/apps/frontend/src/features/space/components/DirectorySetupModal.tsx
@@ -7,8 +7,8 @@ import { ApiError } from "@/api/error";
 import type { SpaceRootValidationCode, SpaceRootValidationResult } from "../types";
 
 type RootValidationState =
-  | { status: 'idle' }
-  | { status: 'validating' }
+  | { status: 'idle'; message?: string; description?: string }
+  | { status: 'validating'; message?: string; description?: string }
   | { status: 'valid'; code: SpaceRootValidationCode; message: string }
   | { status: 'invalid'; code?: SpaceRootValidationCode; message: string; description?: string };
 


### PR DESCRIPTION
## 요약
문제:
frontend browse/space 관련 훅과 테스트에 누적된 lint/typecheck 오류 때문에 `validate` CI가 실패하고 있었습니다.

해결:
queue pump의 선언 전 참조를 정리하고, transfer/trash 타입 import 경계를 바로잡았으며, 테스트 코드의 타입 추론과 testing-library 사용을 현재 타입 정의에 맞게 맞췄습니다.

기대 효과:
`pnpm lint`, `pnpm typecheck`, `pnpm build` 기준선이 다시 통과하고, 이후 PR의 validate 실패 노이즈를 줄일 수 있습니다.

## 관련 이슈
Closes #257

## 변경 사항
- `useArchiveTransfers`, `useUploadTransfers`의 queue pump를 named function expression으로 정리해 lint 오류 제거
- `useDirectDownloadTransfers` unused import 제거
- `useFileOperations`의 `TransferSummary` import와 `readErrorMessage` dependency 누락 정리
- `TrashModal`, `useTrashModalManager`의 `TrashItem` import 경계를 `transferOperationsShared`로 정리
- `FolderContent.test.tsx`, `useFileOperations.test.tsx`, `DirectorySetupModal.test.tsx`의 테스트 타입/유틸 사용 정리
- `DirectorySetupModal.tsx`의 `RootValidationState`를 `message` 접근에 맞게 정리

## 범위
In Scope
- frontend lint/typecheck 기준선 복구
- browse/space 관련 테스트 타입 정리

Out of Scope
- browse transfer 동작 변경
- UI/UX 변경
- 새로운 기능 추가

## 테스트/검증
- `pnpm lint` PASS
- `pnpm typecheck` PASS
- `pnpm build` PASS
- `pnpm --dir apps/frontend exec vitest run src/features/browse/components/FolderContent.test.tsx src/features/browse/hooks/useFileOperations.test.tsx src/features/space/components/DirectorySetupModal.test.tsx` PASS
- `cd apps/backend && go test ./...` PASS

## 리스크 및 대응
- 잠재 리스크: queue pump 재귀 구조 수정이 transfer drain 흐름에 영향 줄 수 있음
- 대응: 구조만 named function expression으로 바꾸고 기존 로직은 유지
- 잠재 리스크: 테스트 유틸 변경이 비동기 시점을 바꿀 수 있음
- 대응: 실제 렌더 결과 대기(`findBy*`)와 microtask flush로 기존 의도를 유지
- 롤백: PR revert 시 기존 상태로 복구 가능

## 리뷰 가이드
- 먼저 볼 파일: `apps/frontend/src/features/browse/hooks/useArchiveTransfers.ts`
- 먼저 볼 파일: `apps/frontend/src/features/browse/hooks/useUploadTransfers.ts`
- 먼저 볼 파일: `apps/frontend/src/features/browse/hooks/useFileOperations.tsx`
- 먼저 볼 파일: `apps/frontend/src/features/space/components/DirectorySetupModal.test.tsx`
- 확인 포인트: lint/typecheck를 깨뜨린 원인 제거가 기능 변경 없이 최소 범위인지

## 체크리스트
- [x] 목표 달성 여부 확인
- [x] 스코프 이탈 없음 확인
- [x] OWASP 관점 보안 점검 완료
- [x] 기존 컨벤션 준수 확인
- [x] 릴리즈 카테고리 라벨 확인 (`fix`)
- [x] 관련 이슈 링크 확인 (`Closes #257`)
- [x] 빌드/테스트 통과
- [x] 영향 범위 점검
- [x] 문서 업데이트(필요 시)
- [x] 브레이킹 변경 없음